### PR TITLE
ci: use stable actionlint path on runners

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -31,7 +31,7 @@ jobs:
       - run: go install github.com/rhysd/actionlint/cmd/actionlint@latest
       - run: chmod +x scripts/*.sh
       - run: ./scripts/ci-lint.sh
-      - run: "$HOME/go/bin/actionlint"
+      - run: /home/runner/go/bin/actionlint
       - run: pnpm dlx markdownlint-cli2 README.md DEVEL.md 'specs/**/*.md' '.github/workflows/*.yml'
       - run: pnpm install --frozen-lockfile
       - run: pnpm run typecheck

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -28,7 +28,7 @@ jobs:
       - run: go install github.com/rhysd/actionlint/cmd/actionlint@latest
       - run: chmod +x scripts/*.sh
       - run: ./scripts/ci-lint.sh
-      - run: "$HOME/go/bin/actionlint"
+      - run: /home/runner/go/bin/actionlint
       - run: pnpm dlx markdownlint-cli2 README.md DEVEL.md 'specs/**/*.md' '.github/workflows/*.yml'
       - run: pnpm install --frozen-lockfile
       - run: pnpm run typecheck

--- a/.github/workflows/main-pr-gate.yml
+++ b/.github/workflows/main-pr-gate.yml
@@ -27,7 +27,7 @@ jobs:
       - run: go install github.com/rhysd/actionlint/cmd/actionlint@latest
       - run: chmod +x scripts/*.sh
       - run: ./scripts/ci-lint.sh
-      - run: "$HOME/go/bin/actionlint"
+      - run: /home/runner/go/bin/actionlint
       - run: pnpm dlx markdownlint-cli2 README.md DEVEL.md 'specs/**/*.md' '.github/workflows/*.yml'
 
   main-typecheck:


### PR DESCRIPTION
## Summary
- use a stable actionlint binary path on GitHub-hosted runners
- avoid shellcheck false positives in workflow lint steps

## Verification
- ./scripts/ci-lint.sh
- YAML parse for .github/workflows/*.yml
