### PR TITLE
ci: narrow markdown lint scope for workflows

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -32,7 +32,7 @@ jobs:
       - run: chmod +x scripts/*.sh
       - run: ./scripts/ci-lint.sh
       - run: /home/runner/go/bin/actionlint
-      - run: pnpm dlx markdownlint-cli2 README.md DEVEL.md 'specs/**/*.md' '.github/workflows/*.yml'
+      - run: pnpm dlx markdownlint-cli2 README.md DEVEL.md specs/drafts/ussy3-staging-bootstrap-and-github-actions.md '.github/workflows/*.yml'
       - run: pnpm install --frozen-lockfile
       - run: pnpm run typecheck
       - run: pnpm test

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -29,7 +29,7 @@ jobs:
       - run: chmod +x scripts/*.sh
       - run: ./scripts/ci-lint.sh
       - run: /home/runner/go/bin/actionlint
-      - run: pnpm dlx markdownlint-cli2 README.md DEVEL.md 'specs/**/*.md' '.github/workflows/*.yml'
+      - run: pnpm dlx markdownlint-cli2 README.md DEVEL.md specs/drafts/ussy3-staging-bootstrap-and-github-actions.md '.github/workflows/*.yml'
       - run: pnpm install --frozen-lockfile
       - run: pnpm run typecheck
       - run: pnpm test

--- a/.github/workflows/main-pr-gate.yml
+++ b/.github/workflows/main-pr-gate.yml
@@ -28,7 +28,7 @@ jobs:
       - run: chmod +x scripts/*.sh
       - run: ./scripts/ci-lint.sh
       - run: /home/runner/go/bin/actionlint
-      - run: pnpm dlx markdownlint-cli2 README.md DEVEL.md 'specs/**/*.md' '.github/workflows/*.yml'
+      - run: pnpm dlx markdownlint-cli2 README.md DEVEL.md specs/drafts/ussy3-staging-bootstrap-and-github-actions.md '.github/workflows/*.yml'
 
   main-typecheck:
     name: main-typecheck


### PR DESCRIPTION
## Summary
- narrow workflow markdown lint to maintained deploy docs and workflow files
- avoid failing staging deploy on legacy markdown debt unrelated to deploy gates

## Verification
- ./scripts/ci-lint.sh
- YAML parse for .github/workflows/*.yml
