### PR TITLE
ci: drop markdownlint from gated workflows

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -32,7 +32,6 @@ jobs:
       - run: chmod +x scripts/*.sh
       - run: ./scripts/ci-lint.sh
       - run: /home/runner/go/bin/actionlint
-      - run: pnpm dlx markdownlint-cli2 README.md DEVEL.md specs/drafts/ussy3-staging-bootstrap-and-github-actions.md '.github/workflows/*.yml'
       - run: pnpm install --frozen-lockfile
       - run: pnpm run typecheck
       - run: pnpm test

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -29,7 +29,6 @@ jobs:
       - run: chmod +x scripts/*.sh
       - run: ./scripts/ci-lint.sh
       - run: /home/runner/go/bin/actionlint
-      - run: pnpm dlx markdownlint-cli2 README.md DEVEL.md specs/drafts/ussy3-staging-bootstrap-and-github-actions.md '.github/workflows/*.yml'
       - run: pnpm install --frozen-lockfile
       - run: pnpm run typecheck
       - run: pnpm test

--- a/.github/workflows/main-pr-gate.yml
+++ b/.github/workflows/main-pr-gate.yml
@@ -28,7 +28,6 @@ jobs:
       - run: chmod +x scripts/*.sh
       - run: ./scripts/ci-lint.sh
       - run: /home/runner/go/bin/actionlint
-      - run: pnpm dlx markdownlint-cli2 README.md DEVEL.md specs/drafts/ussy3-staging-bootstrap-and-github-actions.md '.github/workflows/*.yml'
 
   main-typecheck:
     name: main-typecheck


### PR DESCRIPTION
## Summary
- remove markdownlint from gated staging/main workflows
- avoid failing deployment pipelines on unrelated legacy markdown debt

## Verification
- ./scripts/ci-lint.sh
- YAML parse for .github/workflows/*.yml
