### PR TITLE
ci: drop pnpm cache from main lint job

### DIFF
--- a/.github/workflows/main-pr-gate.yml
+++ b/.github/workflows/main-pr-gate.yml
@@ -22,7 +22,6 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 22
-          cache: pnpm
       - run: sudo apt-get update && sudo apt-get install -y shellcheck
       - run: go install github.com/rhysd/actionlint/cmd/actionlint@latest
       - run: chmod +x scripts/*.sh


### PR DESCRIPTION
## Summary
- remove pnpm cache from main-lint because the job never installs dependencies
- avoid post-job cache save failure on main PR gate

## Verification
- ./scripts/ci-lint.sh
- YAML parse for .github/workflows/*.yml
