### PR TITLE
feat: extract rate limit cooldown from 429 response body + fix OAuth popup

### DIFF
--- a/src/lib/provider-strategy/fallback.ts
+++ b/src/lib/provider-strategy/fallback.ts
@@ -7,7 +7,7 @@ import type { ProviderCredential } from "../key-pool.js";
 import type { PolicyEngine } from "../policy/index.js";
 import type { PromptAffinityStore } from "../prompt-affinity-store.js";
 import type { RequestLogStore } from "../request-log-store.js";
-import { buildUpstreamHeadersForCredential, isRateLimitResponse, parseRetryAfterMs } from "../proxy.js";
+import { buildUpstreamHeadersForCredential, extractRateLimitCooldownMs, isRateLimitResponse } from "../proxy.js";
 import {
   extractTerminalResponseFromEventStream,
   responsesEventStreamToErrorPayload,
@@ -454,7 +454,9 @@ export async function executeProviderFallback(
 
         if (isRateLimitResponse(upstreamResponse)) {
           accumulator.sawRateLimit = true;
-          keyPool.markRateLimited(candidate.account, parseRetryAfterMs(upstreamResponse.headers.get("retry-after")));
+          // Extract cooldown from both header and body
+          const cooldownMs = await extractRateLimitCooldownMs(upstreamResponse);
+          keyPool.markRateLimited(candidate.account, cooldownMs);
           if (
             preferredAffinity
             && candidate.providerId === preferredAffinity.providerId
@@ -689,7 +691,8 @@ export async function executeProviderFallback(
               await refreshedDiagnosticsPromise;
               if (isRateLimitResponse(refreshedResponse)) {
                 accumulator.sawRateLimit = true;
-                keyPool.markRateLimited(refreshedCredential, parseRetryAfterMs(refreshedResponse.headers.get("retry-after")));
+                const refreshedCooldownMs = await extractRateLimitCooldownMs(refreshedResponse);
+                keyPool.markRateLimited(refreshedCredential, refreshedCooldownMs);
                 try {
                   await refreshedResponse.arrayBuffer();
                 } catch {

--- a/src/lib/proxy.ts
+++ b/src/lib/proxy.ts
@@ -104,6 +104,99 @@ export function isRateLimitResponse(response: Response): boolean {
   return response.status === 429;
 }
 
+/**
+ * Parse wait time from rate limit error messages.
+ * Handles OpenAI-style messages like:
+ * - "Please wait 23.5 seconds before making another request."
+ * - "Please try again in 2m30s."
+ * - "Rate limit reached. Please wait 1.37s."
+ */
+export function parseWaitTimeFromMessage(message: string): number | undefined {
+  if (typeof message !== "string") {
+    return undefined;
+  }
+
+  const lower = message.toLowerCase();
+
+  // Pattern: XmYs or Xm Ys (e.g., "2m30s", "2m 30s", "try again in 5m 0s")
+  // Must check this before single minutes pattern
+  const combinedMatch = lower.match(/(\d+)\s*m\s*(\d+)\s*s/i);
+  if (combinedMatch) {
+    const minutes = parseInt(combinedMatch[1]!, 10);
+    const seconds = parseInt(combinedMatch[2]!, 10);
+    if (minutes > 0 || seconds > 0) {
+      return (minutes * 60 + seconds) * 1000;
+    }
+  }
+
+  // Pattern: X.XX seconds or X.XXs (e.g., "23.5 seconds", "1.37s", "30s")
+  const secondsMatch = lower.match(/(\d+(?:\.\d+)?)\s*s(?:econds?)?\b/i);
+  if (secondsMatch) {
+    const seconds = parseFloat(secondsMatch[1]!);
+    if (Number.isFinite(seconds) && seconds > 0) {
+      return Math.ceil(seconds * 1000);
+    }
+  }
+
+  // Pattern: X minute(s) or X min
+  const minutesMatch = lower.match(/(\d+)\s*(?:minutes?|mins?)\b/i);
+  if (minutesMatch) {
+    const minutes = parseInt(minutesMatch[1]!, 10);
+    if (minutes > 0) {
+      return minutes * 60 * 1000;
+    }
+  }
+
+  // Pattern: X hour(s)
+  const hoursMatch = lower.match(/(\d+)\s*(?:hours?|hrs?)\b/i);
+  if (hoursMatch) {
+    const hours = parseInt(hoursMatch[1]!, 10);
+    if (hours > 0) {
+      return hours * 60 * 60 * 1000;
+    }
+  }
+
+  return undefined;
+}
+
+/**
+ * Extract cooldown duration from a 429 response.
+ * First checks the retry-after header, then parses the response body for wait times.
+ */
+export async function extractRateLimitCooldownMs(response: Response): Promise<number | undefined> {
+  // First, try the retry-after header (standard HTTP mechanism)
+  const headerRetryAfter = parseRetryAfterMs(response.headers.get("retry-after"));
+  if (headerRetryAfter !== undefined && headerRetryAfter > 0) {
+    return headerRetryAfter;
+  }
+
+  // Then, try to extract wait time from the response body
+  const contentType = response.headers.get("content-type") ?? "";
+  if (!contentType.includes("application/json") && !contentType.includes("text/")) {
+    return undefined;
+  }
+
+  try {
+    const cloned = response.clone();
+    const body: unknown = await cloned.json();
+
+    // OpenAI-style error: { error: { message: "..." } }
+    if (typeof body === "object" && body !== null) {
+      const error = (body as Record<string, unknown>)["error"];
+      if (typeof error === "object" && error !== null) {
+        const message = (error as Record<string, unknown>)["message"];
+        if (typeof message === "string") {
+          return parseWaitTimeFromMessage(message);
+        }
+      }
+    }
+  } catch {
+    // Ignore JSON parse errors
+  }
+
+  return undefined;
+}
+
 export function openAiError(
   message: string,
   type: string,

--- a/src/tests/proxy-rate-limit.test.ts
+++ b/src/tests/proxy-rate-limit.test.ts
@@ -1,0 +1,177 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { parseWaitTimeFromMessage, parseRetryAfterMs, extractRateLimitCooldownMs } from "../lib/proxy.js";
+
+// ─────────────────────────────────────────────────────────────────────────────
+// parseRetryAfterMs tests
+// ─────────────────────────────────────────────────────────────────────────────
+
+test("parseRetryAfterMs parses seconds as number", () => {
+  assert.equal(parseRetryAfterMs("30"), 30000);
+  assert.equal(parseRetryAfterMs("1.5"), 1500);
+  assert.equal(parseRetryAfterMs("0"), 0);
+});
+
+test("parseRetryAfterMs parses HTTP date format", () => {
+  const future = new Date(Date.now() + 60000).toUTCString();
+  const result = parseRetryAfterMs(future);
+  assert.ok(result !== undefined && result > 55000 && result < 65000);
+});
+
+test("parseRetryAfterMs returns undefined for invalid input", () => {
+  assert.equal(parseRetryAfterMs(null), undefined);
+  assert.equal(parseRetryAfterMs(""), undefined);
+  assert.equal(parseRetryAfterMs("invalid"), undefined);
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// parseWaitTimeFromMessage tests
+// ─────────────────────────────────────────────────────────────────────────────
+
+test("parseWaitTimeFromMessage extracts seconds from 'wait X seconds'", () => {
+  assert.equal(parseWaitTimeFromMessage("Please wait 23.5 seconds before making another request."), 23500);
+  assert.equal(parseWaitTimeFromMessage("Please wait 1 second."), 1000);
+  assert.equal(parseWaitTimeFromMessage("wait 0.5 seconds"), 500);
+});
+
+test("parseWaitTimeFromMessage extracts seconds from 'try again in Xs'", () => {
+  assert.equal(parseWaitTimeFromMessage("Please try again in 1.37s."), 1370);
+  assert.equal(parseWaitTimeFromMessage("Rate limit reached. Try again in 30s"), 30000);
+});
+
+test("parseWaitTimeFromMessage extracts minutes from 'wait X minutes'", () => {
+  assert.equal(parseWaitTimeFromMessage("Please wait 2 minutes before retrying."), 120000);
+  assert.equal(parseWaitTimeFromMessage("Wait 1 minute."), 60000);
+});
+
+test("parseWaitTimeFromMessage extracts combined minutes and seconds (Xm Ys)", () => {
+  assert.equal(parseWaitTimeFromMessage("Please wait 2m 30s before making another request."), 150000);
+  assert.equal(parseWaitTimeFromMessage("try again in 5m 0s"), 300000);
+});
+
+test("parseWaitTimeFromMessage extracts hours", () => {
+  assert.equal(parseWaitTimeFromMessage("Please wait 1 hour before retrying."), 3600000);
+  assert.equal(parseWaitTimeFromMessage("Wait 2 hours."), 7200000);
+});
+
+test("parseWaitTimeFromMessage is case-insensitive", () => {
+  assert.equal(parseWaitTimeFromMessage("PLEASE WAIT 5 SECONDS"), 5000);
+  assert.equal(parseWaitTimeFromMessage("Wait 5 Seconds before making another request."), 5000);
+});
+
+test("parseWaitTimeFromMessage returns undefined for messages without timing", () => {
+  assert.equal(parseWaitTimeFromMessage("Rate limit exceeded."), undefined);
+  assert.equal(parseWaitTimeFromMessage("Service temporarily unavailable."), undefined);
+  assert.equal(parseWaitTimeFromMessage(""), undefined);
+  assert.equal(parseWaitTimeFromMessage("Too many requests."), undefined);
+});
+
+test("parseWaitTimeFromMessage handles OpenAI-style messages", () => {
+  assert.equal(
+    parseWaitTimeFromMessage("You are sending requests too quickly. Please wait 23.5 seconds before making another request."),
+    23500
+  );
+  assert.equal(
+    parseWaitTimeFromMessage("Rate limit reached for requests. Please wait 1.37s."),
+    1370
+  );
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// extractRateLimitCooldownMs tests
+// ─────────────────────────────────────────────────────────────────────────────
+
+test("extractRateLimitCooldownMs prefers retry-after header", async () => {
+  const response = new Response(
+    JSON.stringify({ error: { message: "Please wait 100 seconds" } }),
+    {
+      status: 429,
+      headers: {
+        "content-type": "application/json",
+        "retry-after": "5"
+      }
+    }
+  );
+
+  const result = await extractRateLimitCooldownMs(response);
+  // Header says 5 seconds (5000ms), body says 100 seconds (100000ms)
+  // Header should take precedence
+  assert.equal(result, 5000);
+});
+
+test("extractRateLimitCooldownMs extracts from body when header is missing", async () => {
+  const response = new Response(
+    JSON.stringify({ error: { message: "Please wait 30 seconds before making another request." } }),
+    {
+      status: 429,
+      headers: {
+        "content-type": "application/json"
+      }
+    }
+  );
+
+  const result = await extractRateLimitCooldownMs(response);
+  assert.equal(result, 30000);
+});
+
+test("extractRateLimitCooldownMs returns undefined when no timing info available", async () => {
+  const response = new Response(
+    JSON.stringify({ error: { message: "Rate limit exceeded" } }),
+    {
+      status: 429,
+      headers: {
+        "content-type": "application/json"
+      }
+    }
+  );
+
+  const result = await extractRateLimitCooldownMs(response);
+  assert.equal(result, undefined);
+});
+
+test("extractRateLimitCooldownMs returns undefined for non-JSON response", async () => {
+  const response = new Response(
+    "Rate limit exceeded",
+    {
+      status: 429,
+      headers: {
+        "content-type": "text/plain"
+      }
+    }
+  );
+
+  const result = await extractRateLimitCooldownMs(response);
+  assert.equal(result, undefined);
+});
+
+test("extractRateLimitCooldownMs handles malformed JSON gracefully", async () => {
+  const response = new Response(
+    "not json",
+    {
+      status: 429,
+      headers: {
+        "content-type": "application/json"
+      }
+    }
+  );
+
+  // Should not throw, returns undefined
+  const result = await extractRateLimitCooldownMs(response);
+  assert.equal(result, undefined);
+});
+
+test("extractRateLimitCooldownMs extracts timing from nested error object", async () => {
+  const response = new Response(
+    JSON.stringify({ error: { message: "Please try again in 2 minutes." } }),
+    {
+      status: 429,
+      headers: {
+        "content-type": "application/json"
+      }
+    }
+  );
+
+  const result = await extractRateLimitCooldownMs(response);
+  assert.equal(result, 120000);
+});

--- a/web/src/pages/CredentialsPage.tsx
+++ b/web/src/pages/CredentialsPage.tsx
@@ -472,10 +472,10 @@ export function CredentialsPage(): JSX.Element {
 
     try {
       const payload = await startOpenAiBrowserOAuth(getApiOrigin());
-      const popup = window.open(payload.authorizeUrl, "openai-oauth");
+      const authWindow = window.open(payload.authorizeUrl, "_blank");
 
-      if (!popup) {
-        throw new Error("Browser blocked popup. Allow popups and try again.");
+      if (!authWindow) {
+        throw new Error("Browser blocked the new tab. Allow popups and try again.");
       }
 
       if (browserOAuthWatchRef.current !== null) {
@@ -484,7 +484,7 @@ export function CredentialsPage(): JSX.Element {
       }
 
       browserOAuthWatchRef.current = window.setInterval(() => {
-        if (!popup.closed) {
+        if (!authWindow.closed) {
           return;
         }
 
@@ -498,7 +498,7 @@ export function CredentialsPage(): JSX.Element {
         setStatus("Browser OAuth flow finished. Credentials refreshed.");
       }, 750);
 
-      setStatus("Browser OAuth window opened. Finish sign-in to save credentials.");
+      setStatus("Browser OAuth tab opened. Finish sign-in to save credentials.");
     } catch (oauthError) {
       setError(oauthError instanceof Error ? oauthError.message : String(oauthError));
     }
@@ -572,10 +572,10 @@ export function CredentialsPage(): JSX.Element {
 
     try {
       const payload = await startFactoryBrowserOAuth(getApiOrigin());
-      const popup = window.open(payload.authorizeUrl, "factory-oauth", "popup=yes,width=560,height=720");
+      const authWindow = window.open(payload.authorizeUrl, "_blank");
 
-      if (!popup) {
-        throw new Error("Browser blocked popup. Allow popups and try again.");
+      if (!authWindow) {
+        throw new Error("Browser blocked the new tab. Allow popups and try again.");
       }
 
       if (browserOAuthWatchRef.current !== null) {
@@ -584,7 +584,7 @@ export function CredentialsPage(): JSX.Element {
       }
 
       browserOAuthWatchRef.current = window.setInterval(() => {
-        if (!popup.closed) {
+        if (!authWindow.closed) {
           return;
         }
 
@@ -597,7 +597,7 @@ export function CredentialsPage(): JSX.Element {
         setStatus("Factory.ai browser OAuth flow finished. Credentials refreshed.");
       }, 750);
 
-      setStatus("Factory.ai browser OAuth window opened. Finish sign-in to save credentials.");
+      setStatus("Factory.ai OAuth tab opened. Finish sign-in to save credentials.");
     } catch (oauthError) {
       setError(oauthError instanceof Error ? oauthError.message : String(oauthError));
     }


### PR DESCRIPTION
## Summary

This PR includes two related fixes:

### 1. Rate Limit Cooldown Extraction

Previously, when OpenAI accounts returned 429 rate limit responses, the system only checked the retry-after HTTP header for cooldown duration. If no header was present, accounts would only be deprioritized through health score degradation over time.

Now, the system extracts wait times from both:
- The retry-after HTTP header (existing behavior)
- The response body for messages like "Please wait X seconds" or "try again in 2m 30s"

### 2. OAuth Flow Opens in New Tab

The browser OAuth flows (OpenAI and Factory.ai) now open in a new browser tab instead of a popup window.

## Changes

- src/lib/proxy.ts: Added parseWaitTimeFromMessage() and extractRateLimitCooldownMs()
- src/lib/provider-strategy/fallback.ts: Updated 429 handling to use extracted cooldown
- web/src/pages/CredentialsPage.tsx: Changed window.open() to use _blank target
- src/tests/proxy-rate-limit.test.ts: Added 17 unit tests

## Test Plan

- All 356 existing tests pass
- 17 new unit tests added for rate limit parsing