### PR TITLE
fix: preserve prod shared-edge routes during deploy

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -67,8 +67,8 @@ jobs:
           DEPLOY_USER: ${{ vars.PRODUCTION_SSH_USER || 'error' }}
           DEPLOY_PATH: ${{ vars.PRODUCTION_DEPLOY_PATH || '~/devel/services/proxx' }}
           DEPLOY_COMPOSE_PROJECT_NAME: ${{ vars.PRODUCTION_COMPOSE_PROJECT_NAME || 'open-hax-openai-proxy' }}
-          DEPLOY_COMPOSE_FILES: docker-compose.federation-runtime.yml,deploy/docker-compose.federation.ssl.yml
-          DEPLOY_CADDY_TEMPLATE: deploy/Caddyfile.federation.template
+          DEPLOY_COMPOSE_FILES: docker-compose.federation-runtime.yml,deploy/docker-compose.federation.ssl.yml,deploy/docker-compose.production.shared-edge.yml
+          DEPLOY_CADDY_TEMPLATE: deploy/Caddyfile.production.template
           DEPLOY_HEALTH_SERVICE: federation-nginx
           DEPLOY_RESTART_SERVICES: federation-proxx-a1,federation-proxx-a2,federation-nginx,open-hax-openai-proxy-ssl
           DEPLOY_PUBLIC_HOST: ${{ vars.PRODUCTION_PUBLIC_HOST || 'ussy.promethean.rest' }}
@@ -81,7 +81,7 @@ jobs:
         if: failure()
         run: |
           # shellcheck disable=SC2029,SC2086
-          ssh ${PRODUCTION_SSH_USER}@${PRODUCTION_HOST} "cd ${PRODUCTION_PATH} && docker compose --project-name '${PRODUCTION_PROJECT}' -f docker-compose.federation-runtime.yml -f deploy/docker-compose.federation.ssl.yml ps && docker compose --project-name '${PRODUCTION_PROJECT}' -f docker-compose.federation-runtime.yml -f deploy/docker-compose.federation.ssl.yml logs --tail=200"
+          ssh ${PRODUCTION_SSH_USER}@${PRODUCTION_HOST} "cd ${PRODUCTION_PATH} && docker compose --project-name '${PRODUCTION_PROJECT}' -f docker-compose.federation-runtime.yml -f deploy/docker-compose.federation.ssl.yml -f deploy/docker-compose.production.shared-edge.yml ps && docker compose --project-name '${PRODUCTION_PROJECT}' -f docker-compose.federation-runtime.yml -f deploy/docker-compose.federation.ssl.yml -f deploy/docker-compose.production.shared-edge.yml logs --tail=200"
         env:
           PRODUCTION_HOST: ${{ vars.PRODUCTION_SSH_HOST || 'ussy.promethean.rest' }}
           PRODUCTION_SSH_USER: ${{ vars.PRODUCTION_SSH_USER || 'error' }}

--- a/deploy/Caddyfile.production.template
+++ b/deploy/Caddyfile.production.template
@@ -1,0 +1,86 @@
+__CLUSTER_PUBLIC_HOST__ {
+  encode gzip zstd
+
+  redir /fleet /fleet/ 308
+  handle_path /fleet/* {
+    reverse_proxy host-fleet-dashboard:8791
+  }
+
+  header {
+    Strict-Transport-Security "max-age=31536000; includeSubDomains; preload"
+  }
+
+  reverse_proxy federation-nginx:80
+}
+
+__GROUP_A_PUBLIC_HOST__, __GROUP_B_PUBLIC_HOST__, __A1_PUBLIC_HOST__, __A2_PUBLIC_HOST__, __B1_PUBLIC_HOST__, __B2_PUBLIC_HOST__ {
+  encode gzip zstd
+
+  header {
+    Strict-Transport-Security "max-age=31536000; includeSubDomains; preload"
+  }
+
+  reverse_proxy federation-nginx:80
+}
+
+radar.promethean.rest {
+  encode gzip zstd
+
+  @api path /api* /health /mcp*
+  reverse_proxy @api radar-mcp:10002
+
+  header {
+    Strict-Transport-Security "max-age=31536000; includeSubDomains; preload"
+  }
+
+  reverse_proxy radar-web:80
+}
+
+shibboleth.promethean.rest {
+  encode gzip zstd
+
+  @api path /api*
+  reverse_proxy @api host.docker.internal:8787
+
+  header {
+    Strict-Transport-Security "max-age=31536000; includeSubDomains; preload"
+  }
+
+  reverse_proxy host.docker.internal:5197
+}
+
+battlebussy.__PUBLIC_HOST__ {
+  encode gzip zstd
+
+  @backend path /api* /ws*
+  reverse_proxy @backend battlebussy-backend:8080
+
+  header {
+    Strict-Transport-Security "max-age=31536000; includeSubDomains; preload"
+  }
+
+  reverse_proxy battlebussy-site:3000
+}
+
+voxx.__PUBLIC_HOST__ {
+  encode gzip zstd
+
+  header {
+    Strict-Transport-Security "max-age=31536000; includeSubDomains; preload"
+  }
+
+  reverse_proxy openhax-voxx:8788
+}
+
+gates.__PUBLIC_HOST__ {
+  encode gzip zstd
+
+  @api path /api*
+  reverse_proxy @api host.docker.internal:3300
+
+  header {
+    Strict-Transport-Security "max-age=31536000; includeSubDomains; preload"
+  }
+
+  reverse_proxy host.docker.internal:5175
+}

--- a/deploy/docker-compose.production.shared-edge.yml
+++ b/deploy/docker-compose.production.shared-edge.yml
@@ -1,0 +1,17 @@
+services:
+  open-hax-openai-proxy-ssl:
+    networks:
+      ai-infra: {}
+      battlebussy-edge: {}
+      voxx-edge: {}
+
+networks:
+  ai-infra:
+    external: true
+    name: ai-infra
+  battlebussy-edge:
+    external: true
+    name: battlebussy-prod_default
+  voxx-edge:
+    external: true
+    name: voxx_default


### PR DESCRIPTION
## Summary
- add a production Caddy template that keeps the federation entrypoints while preserving shared edge routes for battlebussy, voxx, radar, shibboleth, gates, and /fleet
- add a production-only compose overlay so the Caddy edge joins the battlebussy and voxx networks on prod
- point the production deploy workflow at the new template/overlay so future main deploys do not wipe the shared edge

## Validation
- docker run caddy validate against a rendered `deploy/Caddyfile.production.template` for `ussy.promethean.rest`
- `docker compose -f docker-compose.federation-runtime.yml -f deploy/docker-compose.federation.ssl.yml -f deploy/docker-compose.production.shared-edge.yml config`
- `actionlint .github/workflows/deploy-production.yml`
- `pnpm install --ignore-workspace --frozen-lockfile`
- `pnpm run build`
- `pnpm test`
- `pnpm run web:build`

## Live note
- restored the live `battlebussy.ussy.promethean.rest` edge on `ussy` immediately so the arena stream is visible again while this promotion path catches up.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated production deployment workflow with enhanced routing configuration and service integration
  * Added new proxy service to production infrastructure with network connectivity

<!-- end of auto-generated comment: release notes by coderabbit.ai -->