### PR TITLE
fix: hidden quota error handling, dashboard surfacing, and analytics error counting

### DIFF
--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -79,6 +79,7 @@ export interface ProxyConfig {
   readonly ollamaWeeklyCooldownMultiplier: number;
   readonly requestTimeoutMs: number;
   readonly streamBootstrapTimeoutMs: number;
+  readonly embedMaxContextTokens: number;
   readonly upstreamTransientRetryCount: number;
   readonly upstreamTransientRetryBackoffMs: number;
   readonly proxyAuthToken?: string;
@@ -547,6 +548,7 @@ export function loadConfig(cwd: string = process.cwd()): ProxyConfig {
     ollamaWeeklyCooldownMultiplier: numberFromEnvAliases(["OLLAMA_WEEKLY_COOLDOWN_MULTIPLIER"], 24),
     requestTimeoutMs: numberFromEnvAliases(["UPSTREAM_REQUEST_TIMEOUT_MS"], 900000),
     streamBootstrapTimeoutMs: numberFromEnvAliases(["UPSTREAM_STREAM_BOOTSTRAP_TIMEOUT_MS"], 8000),
+    embedMaxContextTokens: numberFromEnvAliases(["EMBED_MAX_CONTEXT_TOKENS"], 262144),
     upstreamTransientRetryCount: nonNegativeNumberFromEnvAliases(["UPSTREAM_TRANSIENT_RETRY_COUNT"], 2),
     upstreamTransientRetryBackoffMs: numberFromEnvAliases(["UPSTREAM_TRANSIENT_RETRY_BACKOFF_MS"], 350),
     proxyAuthToken,

--- a/src/lib/ollama-context.ts
+++ b/src/lib/ollama-context.ts
@@ -1,5 +1,8 @@
 import { fetchWithResponseTimeout, isRecord } from "./provider-utils.js";
 
+const contextLengthCache = new Map<string, { length: number; fetchedAt: number }>();
+const CONTEXT_CACHE_TTL_MS = 5 * 60 * 1000;
+
 function asString(value: unknown): string | undefined {
   return typeof value === "string" ? value : undefined;
 }
@@ -116,6 +119,12 @@ export async function fetchOllamaModelContextLength(
   model: string,
   timeoutMs: number,
 ): Promise<number | null> {
+  const cacheKey = `${baseUrl}::${model}`;
+  const cached = contextLengthCache.get(cacheKey);
+  if (cached && Date.now() - cached.fetchedAt < CONTEXT_CACHE_TTL_MS) {
+    return cached.length;
+  }
+
   let response: Awaited<ReturnType<typeof fetchWithResponseTimeout>>;
   try {
     response = await fetchWithResponseTimeout(`${baseUrl.replace(/\/+$/, "")}/api/show`, {
@@ -126,22 +135,22 @@ export async function fetchOllamaModelContextLength(
       body: JSON.stringify({ model }),
     }, timeoutMs);
   } catch {
-    return null;
+    return cached?.length ?? null;
   }
 
   if (!response.ok) {
-    return null;
+    return cached?.length ?? null;
   }
 
   let payload: unknown;
   try {
     payload = await response.json();
   } catch {
-    return null;
+    return cached?.length ?? null;
   }
 
   if (!isRecord(payload)) {
-    return null;
+    return cached?.length ?? null;
   }
 
   const modelInfo = isRecord(payload["model_info"]) ? payload["model_info"] : null;
@@ -152,7 +161,12 @@ export async function fetchOllamaModelContextLength(
     ?? asNumber(modelInfo?.["gemma3.context_length"])
     ?? asNumber(modelInfo?.["general.context_length"]);
 
-  return directContext ?? modelInfoContext ?? null;
+  const result = directContext ?? modelInfoContext ?? null;
+  if (result !== null) {
+    contextLengthCache.set(cacheKey, { length: result, fetchedAt: Date.now() });
+  }
+
+  return result;
 }
 
 export async function ensureOllamaContextFits(

--- a/src/lib/provider-strategy/base.ts
+++ b/src/lib/provider-strategy/base.ts
@@ -37,6 +37,174 @@ function appendUpstreamIdentityHeaders(reply: FastifyReply, context: ProviderAtt
   }
 }
 
+type StreamBootstrapResult =
+  | { kind: "continue"; rateLimit?: true; requestError?: true }
+  | {
+    kind: "ready";
+    reader: ReadableStreamDefaultReader<Uint8Array>;
+    bufferedChunks: Uint8Array[];
+  };
+
+async function cancelStreamReader(reader: ReadableStreamDefaultReader<Uint8Array>): Promise<void> {
+  try {
+    await reader.cancel();
+  } catch {
+    // Ignore cancellation errors while failing over.
+  }
+}
+
+async function readStreamChunkWithTimeout(
+  reader: ReadableStreamDefaultReader<Uint8Array>,
+  timeoutMs: number,
+): Promise<ReadableStreamReadResult<Uint8Array>> {
+  let timeoutHandle: NodeJS.Timeout | undefined;
+
+  try {
+    return await Promise.race([
+      reader.read(),
+      new Promise<ReadableStreamReadResult<Uint8Array>>((_, reject) => {
+        timeoutHandle = setTimeout(() => {
+          reject(new Error("stream bootstrap timeout"));
+        }, timeoutMs);
+      }),
+    ]);
+  } finally {
+    if (timeoutHandle) {
+      clearTimeout(timeoutHandle);
+    }
+  }
+}
+
+async function bootstrapEventStream(
+  upstreamResponse: Response,
+  context: ProviderAttemptContext,
+): Promise<StreamBootstrapResult> {
+  if (!upstreamResponse.body) {
+    return { kind: "continue", requestError: true };
+  }
+
+  const reader = upstreamResponse.body.getReader();
+  const decoder = new TextDecoder();
+  const bufferedChunks: Uint8Array[] = [];
+  let bufferedText = "";
+
+  try {
+    while (true) {
+      const { done, value } = await readStreamChunkWithTimeout(reader, context.upstreamAttemptTimeoutMs);
+
+      if (done) {
+        bufferedText += decoder.decode();
+        const sanitized = stripSseCommentLines(bufferedText);
+
+        if (streamPayloadIndicatesQuotaError(sanitized)) {
+          await cancelStreamReader(reader);
+          return { kind: "continue", rateLimit: true };
+        }
+
+        if (!streamPayloadHasSubstantiveChunks(sanitized)) {
+          await cancelStreamReader(reader);
+          return { kind: "continue", requestError: true };
+        }
+
+        if (context.needsReasoningTrace && context.hasMoreCandidates && !streamPayloadHasReasoningTrace(sanitized)) {
+          await cancelStreamReader(reader);
+          return { kind: "continue", requestError: true };
+        }
+
+        return {
+          kind: "ready",
+          reader,
+          bufferedChunks,
+        };
+      }
+
+      if (!value || value.byteLength === 0) {
+        continue;
+      }
+
+      bufferedChunks.push(value);
+      bufferedText += decoder.decode(value, { stream: true });
+      const sanitized = stripSseCommentLines(bufferedText);
+
+      if (streamPayloadIndicatesQuotaError(sanitized)) {
+        await cancelStreamReader(reader);
+        return { kind: "continue", rateLimit: true };
+      }
+
+      if (!streamPayloadHasSubstantiveChunks(sanitized)) {
+        continue;
+      }
+
+      if (context.needsReasoningTrace && context.hasMoreCandidates && !streamPayloadHasReasoningTrace(sanitized)) {
+        continue;
+      }
+
+      return {
+        kind: "ready",
+        reader,
+        bufferedChunks,
+      };
+    }
+  } catch {
+    await cancelStreamReader(reader);
+    return { kind: "continue", requestError: true };
+  }
+}
+
+async function streamEventStreamToClient(
+  reply: FastifyReply,
+  upstreamResponse: Response,
+  context: ProviderAttemptContext,
+  bootstrap: Extract<StreamBootstrapResult, { kind: "ready" }>,
+): Promise<ProviderAttemptOutcome> {
+  appendUpstreamIdentityHeaders(reply, context);
+  reply.code(upstreamResponse.status);
+  copyUpstreamHeaders(reply, upstreamResponse.headers);
+  reply.removeHeader("content-length");
+  reply.header("cache-control", "no-cache");
+  reply.header("x-accel-buffering", "no");
+  reply.header("content-type", "text/event-stream; charset=utf-8");
+  reply.hijack();
+
+  const rawResponse = reply.raw;
+  rawResponse.statusCode = upstreamResponse.status;
+  for (const [name, value] of Object.entries(reply.getHeaders())) {
+    if (value !== undefined) {
+      rawResponse.setHeader(name, value as never);
+    }
+  }
+  rawResponse.flushHeaders();
+
+  try {
+    for (const chunk of bootstrap.bufferedChunks) {
+      rawResponse.write(chunk);
+    }
+
+    while (!rawResponse.writableEnded) {
+      const { done, value } = await bootstrap.reader.read();
+      if (done) {
+        break;
+      }
+
+      if (value && value.byteLength > 0) {
+        rawResponse.write(value);
+      }
+    }
+  } finally {
+    try {
+      bootstrap.reader.releaseLock();
+    } catch {
+      // Ignore reader release errors while closing the downstream stream.
+    }
+
+    if (!rawResponse.writableEnded) {
+      rawResponse.end();
+    }
+  }
+
+  return { kind: "handled" };
+}
+
 export abstract class BaseProviderStrategy implements ProviderStrategy {
   public abstract readonly mode: UpstreamMode;
   public abstract readonly isLocal: boolean;
@@ -260,54 +428,12 @@ export abstract class BaseProviderStrategy implements ProviderStrategy {
     }
 
     if (context.clientWantsStream) {
-      if (!upstreamResponse.body) {
-        return {
-          kind: "continue",
-          requestError: true
-        };
+      const bootstrap = await bootstrapEventStream(upstreamResponse, context);
+      if (bootstrap.kind === "continue") {
+        return bootstrap;
       }
 
-      const streamText = stripSseCommentLines(await upstreamResponse.text());
-      if (streamPayloadIndicatesQuotaError(streamText) && context.hasMoreCandidates) {
-        return {
-          kind: "continue",
-          rateLimit: true
-        };
-      }
-
-      if (!streamPayloadHasSubstantiveChunks(streamText) && context.hasMoreCandidates) {
-        return {
-          kind: "continue",
-          requestError: true
-        };
-      }
-
-      if (context.needsReasoningTrace && !streamPayloadHasReasoningTrace(streamText) && context.hasMoreCandidates) {
-        return {
-          kind: "continue",
-          requestError: true
-        };
-      }
-
-      appendUpstreamIdentityHeaders(reply, context);
-      reply.code(upstreamResponse.status);
-      copyUpstreamHeaders(reply, upstreamResponse.headers);
-      reply.removeHeader("content-length");
-      reply.header("cache-control", "no-cache");
-      reply.header("x-accel-buffering", "no");
-      reply.header("content-type", "text/event-stream; charset=utf-8");
-      reply.hijack();
-      const rawResponse = reply.raw;
-      rawResponse.statusCode = upstreamResponse.status;
-      for (const [name, value] of Object.entries(reply.getHeaders())) {
-        if (value !== undefined) {
-          rawResponse.setHeader(name, value as never);
-        }
-      }
-      rawResponse.flushHeaders();
-      rawResponse.write(streamText);
-      rawResponse.end();
-      return { kind: "handled" };
+      return streamEventStreamToClient(reply, upstreamResponse, context, bootstrap);
     }
 
     appendUpstreamIdentityHeaders(reply, context);

--- a/src/lib/provider-strategy/fallback/legacy.ts
+++ b/src/lib/provider-strategy/fallback/legacy.ts
@@ -106,6 +106,12 @@ function candidateMatchesAffinity(
     && candidate.account.accountId === affinity.accountId;
 }
 
+/**
+ * Executes the provider routing plan: iterates over fallback candidates,
+ * attempts each one, and handles success/failure/rate-limit outcomes.
+ * Supports prompt-cache-key affinity for session stickiness and
+ * hidden quota error detection (200 OK with error in stream body).
+ */
 export async function executeProviderRoutingPlan(
   strategy: ProviderStrategy,
   reply: FastifyReply,
@@ -704,6 +710,12 @@ export async function executeProviderRoutingPlan(
           }
         }
 
+        /**
+         * Handle hidden upstream errors: providers that return 200 OK but carry a
+         * quota error ("stream_quota_error") or empty/invalid body ("stream_empty_or_invalid")
+         * in the SSE stream. These accounts must be put into cooldown and the sticky
+         * affinity record deleted so the fallback loop can try the next candidate.
+         */
         if (upstreamResponse.ok && (outcome.rateLimit === true || outcome.requestError === true)) {
           const cooldownMs = outcome.rateLimit === true
             ? context.config.keyCooldownMs

--- a/src/lib/provider-strategy/fallback/legacy.ts
+++ b/src/lib/provider-strategy/fallback/legacy.ts
@@ -734,13 +734,12 @@ export async function executeProviderRoutingPlan(
             });
           }
           if (
-            preferredAffinity
-            && candidate.providerId === preferredAffinity.providerId
-            && candidate.account.accountId === preferredAffinity.accountId
+            candidateMatchesAffinity(candidate, preferredAffinity)
+            || candidateMatchesAffinity(candidate, provisionalAffinity)
           ) {
             preferredReassignmentAllowed = true;
           }
-          if (outcome.rateLimit === true && promptCacheKey && candidateMatchesAffinity(candidate, preferredAffinity)) {
+          if (outcome.rateLimit === true && promptCacheKey && (candidateMatchesAffinity(candidate, preferredAffinity) || candidateMatchesAffinity(candidate, provisionalAffinity))) {
             await promptAffinityStore.delete(promptCacheKey);
           }
         }

--- a/src/lib/provider-strategy/fallback/legacy.ts
+++ b/src/lib/provider-strategy/fallback/legacy.ts
@@ -704,6 +704,35 @@ export async function executeProviderRoutingPlan(
           }
         }
 
+        if (upstreamResponse.ok && (outcome.rateLimit === true || outcome.requestError === true)) {
+          const cooldownMs = outcome.rateLimit === true
+            ? context.config.keyCooldownMs
+            : Math.min(context.config.keyCooldownMs, 10_000);
+          keyPool.markRateLimited(candidate.account, cooldownMs);
+          await providerRoutePheromoneStore.noteFailure(candidate.providerId, context.routedModel);
+          if (outcome.rateLimit === true) {
+            requestLogStore.update(requestLogEntryId, {
+              upstreamErrorCode: "stream_quota_error",
+              upstreamErrorMessage: "200 OK with quota error in stream body",
+            });
+          } else {
+            requestLogStore.update(requestLogEntryId, {
+              upstreamErrorCode: "stream_empty_or_invalid",
+              upstreamErrorMessage: "200 OK with no substantive content in stream body",
+            });
+          }
+          if (
+            preferredAffinity
+            && candidate.providerId === preferredAffinity.providerId
+            && candidate.account.accountId === preferredAffinity.accountId
+          ) {
+            preferredReassignmentAllowed = true;
+          }
+          if (outcome.rateLimit === true && promptCacheKey && candidateMatchesAffinity(candidate, preferredAffinity)) {
+            await promptAffinityStore.delete(promptCacheKey);
+          }
+        }
+
         accumulator.sawRateLimit ||= outcome.rateLimit === true;
         accumulator.sawRequestError ||= outcome.requestError === true;
         accumulator.sawUpstreamServerError ||= outcome.upstreamServerError === true;
@@ -960,7 +989,7 @@ export async function executeProviderRoutingPlan(
   return {
     handled: false,
     candidateCount: candidates.length,
-    summary: accumulator
+    summary: accumulator,
   };
 }
 

--- a/src/lib/request-log-store.ts
+++ b/src/lib/request-log-store.ts
@@ -892,14 +892,16 @@ function sumCount(value: number | undefined): number {
 function isRequestLogEntryError(entry: {
   readonly status: number;
   readonly error?: string;
+  readonly upstreamErrorCode?: string;
 }): boolean {
-  return entry.status >= 400 || typeof entry.error === "string";
+  return entry.status >= 400 || typeof entry.error === "string" || typeof entry.upstreamErrorCode === "string";
 }
 
 function countsTowardCacheKeyUse(entry: {
   readonly promptCacheKeyUsed?: boolean;
   readonly status: number;
   readonly error?: string;
+  readonly upstreamErrorCode?: string;
 }): boolean {
   return entry.promptCacheKeyUsed === true && !isRequestLogEntryError(entry);
 }
@@ -908,6 +910,7 @@ function countsTowardCacheHit(entry: {
   readonly cacheHit?: boolean;
   readonly status: number;
   readonly error?: string;
+  readonly upstreamErrorCode?: string;
 }): boolean {
   return entry.cacheHit === true && !isRequestLogEntryError(entry);
 }

--- a/src/routes/api/ui/analytics/usage.ts
+++ b/src/routes/api/ui/analytics/usage.ts
@@ -185,6 +185,7 @@ function usageCount(value: number | undefined): number {
   return typeof value === "number" && Number.isFinite(value) ? value : 0;
 }
 
+/** Returns `part` as a percentage of `total`, or 0 when `total` is non-positive. */
 function percentage(part: number, total: number): number {
   if (total <= 0) {
     return 0;
@@ -193,6 +194,12 @@ function percentage(part: number, total: number): number {
   return Number(((part / total) * 100).toFixed(2));
 }
 
+/**
+ * Determines whether a request log entry represents a failed request.
+ * Counts entries with HTTP error status (>= 400), an `error` string,
+ * or an `upstreamErrorCode` (e.g. "stream_quota_error" on 200 OK responses
+ * that carry a quota error in the SSE body).
+ */
 function isRequestLogError(entry: {
   readonly status: number;
   readonly error?: string;
@@ -201,6 +208,7 @@ function isRequestLogError(entry: {
   return entry.status >= 400 || typeof entry.error === "string" || typeof entry.upstreamErrorCode === "string";
 }
 
+/** Returns 1 when the entry used a prompt cache key and is not an error, otherwise 0. */
 function cacheKeyUseCountForEntry(entry: {
   readonly promptCacheKeyUsed?: boolean;
   readonly status: number;
@@ -209,6 +217,7 @@ function cacheKeyUseCountForEntry(entry: {
   return entry.promptCacheKeyUsed === true && !isRequestLogError(entry) ? 1 : 0;
 }
 
+/** Returns 1 when the entry had a cache hit and is not an error, otherwise 0. */
 function cacheHitCountForEntry(entry: {
   readonly cacheHit?: boolean;
   readonly status: number;

--- a/src/routes/api/ui/analytics/usage.ts
+++ b/src/routes/api/ui/analytics/usage.ts
@@ -213,6 +213,7 @@ function cacheKeyUseCountForEntry(entry: {
   readonly promptCacheKeyUsed?: boolean;
   readonly status: number;
   readonly error?: string;
+  readonly upstreamErrorCode?: string;
 }): number {
   return entry.promptCacheKeyUsed === true && !isRequestLogError(entry) ? 1 : 0;
 }
@@ -222,6 +223,7 @@ function cacheHitCountForEntry(entry: {
   readonly cacheHit?: boolean;
   readonly status: number;
   readonly error?: string;
+  readonly upstreamErrorCode?: string;
 }): number {
   return entry.cacheHit === true && !isRequestLogError(entry) ? 1 : 0;
 }

--- a/src/routes/api/ui/analytics/usage.ts
+++ b/src/routes/api/ui/analytics/usage.ts
@@ -196,8 +196,9 @@ function percentage(part: number, total: number): number {
 function isRequestLogError(entry: {
   readonly status: number;
   readonly error?: string;
+  readonly upstreamErrorCode?: string;
 }): boolean {
-  return entry.status >= 400 || typeof entry.error === "string";
+  return entry.status >= 400 || typeof entry.error === "string" || typeof entry.upstreamErrorCode === "string";
 }
 
 function cacheKeyUseCountForEntry(entry: {

--- a/src/routes/embeddings.ts
+++ b/src/routes/embeddings.ts
@@ -62,23 +62,32 @@ export function registerEmbeddingsRoutes(deps: AppDeps, app: FastifyInstance): v
       Math.min(deps.config.requestTimeoutMs, 30_000),
     );
 
-    if (embedBudget && embedBudget.requiredContextTokens > embedBudget.availableContextTokens) {
+    const maxContextTokens = Math.min(
+      deps.config.embedMaxContextTokens,
+      embedBudget?.contextLength ?? deps.config.embedMaxContextTokens,
+    );
+
+    if (embedBudget && embedBudget.estimatedInputTokens > maxContextTokens) {
       sendOpenAiError(
         reply,
         400,
-        `Embedding request exceeds model context window for ${embedBudget.model}. Estimated input tokens: ${embedBudget.estimatedInputTokens}, available: ${embedBudget.availableContextTokens}. Reduce input size or split the document before embedding.`,
+        `Embedding request exceeds model context window for ${embedBudget.model}. Estimated input tokens: ${embedBudget.estimatedInputTokens}, maximum: ${maxContextTokens}. Reduce input size or split the document before embedding.`,
         "invalid_request_error",
-        "ollama_context_overflow",
+        "embed_context_overflow",
       );
       return;
     }
+
+    const autoNumCtx = embedBudget && embedBudget.requiredContextTokens > embedBudget.availableContextTokens
+      ? Math.min(maxContextTokens, embedBudget.recommendedNumCtx)
+      : undefined;
 
     const upstreamBody = nativeEmbedToOllamaRequest(
       {
         ...request.body,
         model: routedModel,
       },
-      embedBudget?.availableContextTokens,
+      autoNumCtx ?? embedBudget?.availableContextTokens,
     );
 
     let upstreamResponse: Response;

--- a/src/tests/factory-strategy.test.ts
+++ b/src/tests/factory-strategy.test.ts
@@ -162,6 +162,7 @@ async function withProxyApp(
     ollamaWeeklyCooldownMultiplier: 24,
     requestTimeoutMs: 2000,
     streamBootstrapTimeoutMs: 2000,
+    embedMaxContextTokens: 262144,
     upstreamTransientRetryCount: 0,
     upstreamTransientRetryBackoffMs: 1,
     allowUnauthenticated: true,

--- a/src/tests/federation-bridge-agent.test.ts
+++ b/src/tests/federation-bridge-agent.test.ts
@@ -104,6 +104,7 @@ async function withBridgeApp(
     ollamaWeeklyCooldownMultiplier: 24,
     requestTimeoutMs: 2_000,
     streamBootstrapTimeoutMs: 2_000,
+    embedMaxContextTokens: 262144,
     upstreamTransientRetryCount: 1,
     upstreamTransientRetryBackoffMs: 1,
     proxyAuthToken: options.proxyAuthToken ?? "bridge-admin-token",

--- a/src/tests/federation-bridge-autostart.test.ts
+++ b/src/tests/federation-bridge-autostart.test.ts
@@ -126,6 +126,7 @@ function buildConfig(input: {
     ollamaWeeklyCooldownMultiplier: 24,
     requestTimeoutMs: 2_000,
     streamBootstrapTimeoutMs: 2_000,
+    embedMaxContextTokens: 262144,
     upstreamTransientRetryCount: 1,
     upstreamTransientRetryBackoffMs: 1,
     proxyAuthToken: input.proxyAuthToken,

--- a/src/tests/federation-bridge-relay.test.ts
+++ b/src/tests/federation-bridge-relay.test.ts
@@ -98,6 +98,7 @@ function buildConfig(input: {
     ollamaWeeklyCooldownMultiplier: 24,
     requestTimeoutMs: 2_000,
     streamBootstrapTimeoutMs: 2_000,
+    embedMaxContextTokens: 262144,
     upstreamTransientRetryCount: 1,
     upstreamTransientRetryBackoffMs: 1,
     proxyAuthToken: input.proxyAuthToken,

--- a/src/tests/provider-catalog.test.ts
+++ b/src/tests/provider-catalog.test.ts
@@ -59,6 +59,7 @@ function buildMinimalConfig(overrides: Partial<ProxyConfig> = {}): ProxyConfig {
     ollamaWeeklyCooldownMultiplier: 24,
     requestTimeoutMs: 180000,
     streamBootstrapTimeoutMs: 5000,
+    embedMaxContextTokens: 262144,
     upstreamTransientRetryCount: 2,
     upstreamTransientRetryBackoffMs: 1,
     proxyAuthToken: undefined,

--- a/src/tests/proxy.test.ts
+++ b/src/tests/proxy.test.ts
@@ -189,6 +189,7 @@ async function withProxyApp(
     ollamaWeeklyCooldownMultiplier: 24,
     requestTimeoutMs: 2000,
     streamBootstrapTimeoutMs: 2000,
+    embedMaxContextTokens: 262144,
     upstreamTransientRetryCount: 2,
     upstreamTransientRetryBackoffMs: 1,
     proxyAuthToken: options.proxyAuthToken,
@@ -9712,7 +9713,8 @@ test("fails over stream accounts when the first upstream stream handshake times 
       keys: ["key-slow", "key-fast"],
       configOverrides: {
         requestTimeoutMs: 1000,
-        streamBootstrapTimeoutMs: 50
+        streamBootstrapTimeoutMs: 50,
+        embedMaxContextTokens: 262144,
       },
       upstreamHandler: async (request) => {
         const auth = request.headers.authorization;
@@ -9764,6 +9766,193 @@ test("fails over stream accounts when the first upstream stream handshake times 
       assert.equal(response.statusCode, 200);
       assert.ok(response.body.includes("stream-timeout-fallback-ok"));
       assert.deepEqual(observedKeys, ["key-slow", "key-fast"]);
+    }
+  );
+});
+
+test("fails over stream accounts when the first upstream stream sends headers but never boots", async () => {
+  const observedKeys: string[] = [];
+
+  await withProxyApp(
+    {
+      keys: ["key-stalled", "key-fast"],
+      configOverrides: {
+        requestTimeoutMs: 1000,
+        streamBootstrapTimeoutMs: 50,
+        embedMaxContextTokens: 262144,
+      },
+      upstreamHandler: async (request) => {
+        const auth = request.headers.authorization;
+        if (typeof auth === "string") {
+          observedKeys.push(auth.replace(/^Bearer\s+/i, ""));
+        }
+
+        if (auth === "Bearer key-stalled") {
+          return {
+            status: 200,
+            headers: {
+              "content-type": "text/event-stream"
+            },
+            streamBody: async (response) => {
+              response.flushHeaders();
+              await new Promise((resolve) => {
+                setTimeout(resolve, 200);
+              });
+              response.write(
+                "data: {\"id\":\"chatcmpl_stream_stalled\",\"object\":\"chat.completion.chunk\",\"created\":1772516802,\"model\":\"glm-5\",\"choices\":[{\"index\":0,\"delta\":{\"role\":\"assistant\",\"content\":\"too-late\"},\"finish_reason\":null}]}\n\n"
+              );
+              response.write("data: [DONE]\n\n");
+              response.end();
+            },
+          };
+        }
+
+        return {
+          status: 200,
+          headers: {
+            "content-type": "text/event-stream"
+          },
+          body:
+            "data: {\"id\":\"chatcmpl_stream_bootstrap_fallback\",\"object\":\"chat.completion.chunk\",\"created\":1772516802,\"model\":\"glm-5\",\"choices\":[{\"index\":0,\"delta\":{\"role\":\"assistant\",\"content\":\"stream-bootstrap-fallback-ok\"},\"finish_reason\":null}]}\n\n" +
+            "data: {\"id\":\"chatcmpl_stream_bootstrap_fallback\",\"object\":\"chat.completion.chunk\",\"created\":1772516802,\"model\":\"glm-5\",\"choices\":[{\"index\":0,\"delta\":{},\"finish_reason\":\"stop\"}]}\n\n" +
+            "data: [DONE]\n\n"
+        };
+      }
+    },
+    async ({ app }) => {
+      const response = await app.inject({
+        method: "POST",
+        url: "/v1/chat/completions",
+        headers: {
+          "content-type": "application/json"
+        },
+        payload: {
+          model: "glm-5",
+          messages: [{ role: "user", content: "hello" }],
+          stream: true
+        }
+      });
+
+      assert.equal(response.statusCode, 200);
+      assert.ok(response.body.includes("stream-bootstrap-fallback-ok"));
+      assert.deepEqual(observedKeys, ["key-stalled", "key-fast"]);
+    }
+  );
+});
+
+test("returns 502 when the final upstream stream has no substantive chunks", async () => {
+  await withProxyApp(
+    {
+      keys: ["key-empty"],
+      upstreamHandler: async () => ({
+        status: 200,
+        headers: {
+          "content-type": "text/event-stream"
+        },
+        body: "data: [DONE]\n\n"
+      })
+    },
+    async ({ app }) => {
+      const response = await app.inject({
+        method: "POST",
+        url: "/v1/chat/completions",
+        headers: {
+          "content-type": "application/json"
+        },
+        payload: {
+          model: "glm-5",
+          messages: [{ role: "user", content: "hello" }],
+          stream: true
+        }
+      });
+
+      assert.equal(response.statusCode, 502);
+      const payload: unknown = response.json();
+      assert.ok(isRecord(payload));
+      assert.ok(isRecord(payload.error));
+      assert.equal(payload.error.code, "upstream_unavailable");
+    }
+  );
+});
+
+test("starts hosted upstream streams after the first substantive chunk instead of buffering the full body", async () => {
+  let upstreamCompleted = false;
+
+  await withProxyApp(
+    {
+      keys: ["key-a"],
+      upstreamHandler: async () => ({
+        status: 200,
+        headers: {
+          "content-type": "text/event-stream"
+        },
+        streamBody: async (response) => {
+          response.flushHeaders();
+          response.write(
+            "data: {\"id\":\"chatcmpl_stream_early\",\"object\":\"chat.completion.chunk\",\"created\":1772516802,\"model\":\"glm-5\",\"choices\":[{\"index\":0,\"delta\":{\"role\":\"assistant\",\"content\":\"early-hosted-stream\"},\"finish_reason\":null}]}\n\n"
+          );
+          await new Promise((resolve) => {
+            setTimeout(resolve, 250);
+          });
+          response.write(
+            "data: {\"id\":\"chatcmpl_stream_early\",\"object\":\"chat.completion.chunk\",\"created\":1772516802,\"model\":\"glm-5\",\"choices\":[{\"index\":0,\"delta\":{},\"finish_reason\":\"stop\"}]}\n\n"
+          );
+          response.write("data: [DONE]\n\n");
+          upstreamCompleted = true;
+          response.end();
+        },
+      })
+    },
+    async ({ app }) => {
+      await app.listen({ host: "127.0.0.1", port: 0 });
+      const address = app.server.address();
+      if (!address || typeof address === "string") {
+        throw new Error("Failed to resolve app address");
+      }
+
+      const response = await Promise.race([
+        fetch(`http://127.0.0.1:${address.port}/v1/chat/completions`, {
+          method: "POST",
+          headers: {
+            "content-type": "application/json"
+          },
+          body: JSON.stringify({
+            model: "glm-5",
+            messages: [{ role: "user", content: "hello" }],
+            stream: true
+          })
+        }),
+        new Promise<never>((_, reject) => {
+          setTimeout(() => {
+            reject(new Error("timed out waiting for streamed response headers"));
+          }, 100);
+        })
+      ]);
+
+      assert.equal(response.status, 200);
+      assert.equal(response.headers.get("content-type"), "text/event-stream; charset=utf-8");
+      assert.ok(response.body);
+
+      const reader = response.body.getReader();
+      const decoder = new TextDecoder();
+      let buffer = "";
+
+      try {
+        while (!buffer.includes("\n\n")) {
+          const { done, value } = await reader.read();
+          assert.equal(done, false);
+          buffer += decoder.decode(value, { stream: true });
+        }
+      } finally {
+        await reader.cancel();
+      }
+
+      assert.equal(upstreamCompleted, false);
+      const firstEvent = parseSseDataPayloads(buffer)[0];
+      assert.ok(firstEvent);
+      const firstChunk = JSON.parse(firstEvent);
+      assert.equal(firstChunk.object, "chat.completion.chunk");
+      assert.equal(firstChunk.choices[0].delta.content, "early-hosted-stream");
     }
   );
 });

--- a/src/tests/tenant-provider-policy-routes.test.ts
+++ b/src/tests/tenant-provider-policy-routes.test.ts
@@ -86,6 +86,7 @@ function buildConfig(input: {
     ollamaWeeklyCooldownMultiplier: 24,
     requestTimeoutMs: 2_000,
     streamBootstrapTimeoutMs: 2_000,
+    embedMaxContextTokens: 262144,
     upstreamTransientRetryCount: 1,
     upstreamTransientRetryBackoffMs: 1,
     proxyAuthToken: input.proxyAuthToken,

--- a/web/src/pages/DashboardPage.tsx
+++ b/web/src/pages/DashboardPage.tsx
@@ -205,6 +205,7 @@ function serviceTierShareBars(summary: UsageOverview["summary"]): JSX.Element {
   );
 }
 
+/** Dashboard page: shows request log, provider health, and account status. */
 export function DashboardPage(): JSX.Element {
   const [overview, setOverview] = useState<UsageOverview | null>(null);
   const [keyPoolStatuses, setKeyPoolStatuses] = useState<Record<string, KeyPoolStatus>>({});

--- a/web/src/pages/DashboardPage.tsx
+++ b/web/src/pages/DashboardPage.tsx
@@ -530,8 +530,13 @@ export function DashboardPage(): JSX.Element {
                 <Badge variant={entry.serviceTierSource === "fast_mode" ? "info" : "default"}>
                   {formatServiceTier(entry)}
                 </Badge>
-                <Badge variant={entry.status === 0 || entry.status >= 400 ? "error" : "success"}>
+                <Badge variant={
+                  entry.status === 0 || entry.status >= 400 ? "error"
+                  : entry.upstreamErrorCode ? "warning"
+                  : "success"
+                }>
                   {entry.status === 0 ? "ERR" : entry.status}
+                  {entry.upstreamErrorCode ? ` ${entry.upstreamErrorCode}` : ""}
                 </Badge>
                 <span>{Math.round(entry.latencyMs)} ms</span>
               </div>


### PR DESCRIPTION
## Summary

Follow-up to #172 with fixes for hidden quota errors, dashboard surfacing, and analytics.

### Changes
- **Hidden quota error handling**: When ollama-cloud returns 200 OK with a quota error in the SSE stream body, the fallback loop now correctly marks the account as rate-limited, deletes the sticky affinity record, and allows reassignment (previously these 200 OK accounts were never put into cooldown, causing the loop to cycle through all accounts without ever sending a response)
- **Dashboard surfacing**: Hidden quota errors (200 OK with error in body) now show a yellow warning badge with `upstreamErrorCode` text instead of misleading green "200" badges
- **Analytics error counting**: `isRequestLogError` now also checks `upstreamErrorCode` so entries with `stream_quota_error` are counted as errors in analytics (previously only `status >= 400` or `error` string were counted)

### Commits since #172
- `0557118` fix: handle hidden quota errors in 200 OK stream bodies
- `64281f3` fix: count upstreamErrorCode entries as errors in analytics

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Upstream-error entries are now excluded from cache/use metrics; analytics reflect this.
  * Dashboard status badges show upstream error codes and use a warning state for upstream-coded issues.

* **Behavioral Improvements**
  * Improved provider fallback handling: smarter cooldowns, preferred-account adjustments, and prompt-affinity clearing on rate limits.
  * Streaming reliability and failover improved; hosted streams begin forwarding earlier.

* **New Features**
  * Added configurable embed max-context limit and a short-lived cache for external model context lookups.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->