### PR TITLE
Data-oriented routing: schemas, processors, cache policy, and pipeline skeleton

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -1,0 +1,20 @@
+{;; Paths linted by default when running `clj-kondo --lint src/proxx test/proxx`
+ :paths ["src" "test"]
+
+ :linters
+ {:unused-namespace        {:level :warning}
+  :unused-referred-var     {:level :warning}
+  :unresolved-symbol       {:level :error}
+  :unresolved-namespace    {:level :error}
+  :missing-docstring       {:level :off}       ;; noisy during initial dev; flip to :info later
+  :single-segment-namespace {:level :warning}  ;; nudge toward proxx.* not bare names
+  :shadowed-var            {:level :warning}}
+
+ ;; shadow-cljs test macro support
+ :lint-as
+ {shadow.test/deftest cljs.test/deftest}
+
+ ;; Don't warn on Malli's use of unqualified schema forms
+ :config-in-ns
+ {proxx.schema           {:linters {:unresolved-symbol {:level :off}}}
+  proxx.ledger.schema    {:linters {:unresolved-symbol {:level :off}}}}}

--- a/.github/workflows/cljs-test.yml
+++ b/.github/workflows/cljs-test.yml
@@ -35,9 +35,6 @@ jobs:
         with:
           node-version: 22
 
-      # Java is required by shadow-cljs to run the Clojure compiler.
-      # No cache: param — shadow-cljs manages its own Maven deps; we cache
-      # ~/.m2/repository explicitly below to avoid re-downloading on every run.
       - uses: actions/setup-java@v4
         with:
           distribution: temurin
@@ -51,7 +48,6 @@ jobs:
           key: shadow-cljs-${{ runner.os }}-${{ hashFiles('shadow-cljs.edn') }}
           restore-keys: shadow-cljs-${{ runner.os }}-
 
-      # Install shadow-cljs globally — avoids touching the (broken) pnpm lockfile.
       - name: Install shadow-cljs
         run: npm install -g shadow-cljs
 
@@ -59,7 +55,7 @@ jobs:
         run: shadow-cljs compile node-test
 
       - name: Run CLJS tests
-        run: node target/node-test.js
+        run: node target/node-test.cjs
 
   cljs-lint:
     name: cljs-lint
@@ -79,7 +75,6 @@ jobs:
           key: clj-kondo-${{ runner.os }}-${{ hashFiles('shadow-cljs.edn') }}
           restore-keys: clj-kondo-${{ runner.os }}-
 
-      # clj-kondo native binary via npm — no pnpm lockfile needed.
       - name: Install clj-kondo
         run: npm install -g clj-kondo
 

--- a/.github/workflows/cljs-test.yml
+++ b/.github/workflows/cljs-test.yml
@@ -31,35 +31,32 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 9
-
       - uses: actions/setup-node@v5
         with:
           node-version: 22
-          cache: pnpm
 
+      # Java is required by shadow-cljs to run the Clojure compiler.
+      # No cache: param — shadow-cljs manages its own Maven deps; we cache
+      # ~/.m2/repository explicitly below to avoid re-downloading on every run.
       - uses: actions/setup-java@v4
         with:
           distribution: temurin
           java-version: 21
-          cache: maven
 
-      # Restore shadow-cljs compilation cache between runs
       - uses: actions/cache@v4
         with:
           path: |
             .shadow-cljs
             ~/.m2/repository
-          key: shadow-cljs-${{ runner.os }}-${{ hashFiles('shadow-cljs.edn', 'package.json') }}
+          key: shadow-cljs-${{ runner.os }}-${{ hashFiles('shadow-cljs.edn') }}
           restore-keys: shadow-cljs-${{ runner.os }}-
 
-      - name: Install JS deps
-        run: pnpm install --frozen-lockfile
+      # Install shadow-cljs globally — avoids touching the (broken) pnpm lockfile.
+      - name: Install shadow-cljs
+        run: npm install -g shadow-cljs
 
       - name: Compile CLJS tests
-        run: pnpm exec shadow-cljs compile node-test
+        run: shadow-cljs compile node-test
 
       - name: Run CLJS tests
         run: node target/node-test.js
@@ -72,28 +69,19 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 9
-
       - uses: actions/setup-node@v5
         with:
           node-version: 22
-          cache: pnpm
 
-      - name: Install JS deps
-        run: pnpm install --frozen-lockfile
-
-      # clj-kondo ships as a native binary via the npm wrapper
-      - name: Install clj-kondo
-        run: pnpm add -g clj-kondo || npm install -g clj-kondo || true
-
-      # Populate clj-kondo cache for deps declared in shadow-cljs.edn
       - uses: actions/cache@v4
         with:
           path: .clj-kondo/.cache
           key: clj-kondo-${{ runner.os }}-${{ hashFiles('shadow-cljs.edn') }}
           restore-keys: clj-kondo-${{ runner.os }}-
+
+      # clj-kondo native binary via npm — no pnpm lockfile needed.
+      - name: Install clj-kondo
+        run: npm install -g clj-kondo
 
       - name: clj-kondo lint
         run: clj-kondo --lint src/proxx test/proxx

--- a/.github/workflows/cljs-test.yml
+++ b/.github/workflows/cljs-test.yml
@@ -1,0 +1,99 @@
+name: cljs-test
+
+on:
+  pull_request:
+    branches:
+      - main
+      - staging
+    paths:
+      - 'src/proxx/**'
+      - 'test/proxx/**'
+      - 'shadow-cljs.edn'
+      - '.github/workflows/cljs-test.yml'
+  push:
+    branches:
+      - main
+    paths:
+      - 'src/proxx/**'
+      - 'test/proxx/**'
+      - 'shadow-cljs.edn'
+
+permissions:
+  contents: read
+  checks: write
+
+jobs:
+  cljs-unit-tests:
+    name: cljs-unit-tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - uses: actions/setup-node@v5
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 21
+          cache: maven
+
+      # Restore shadow-cljs compilation cache between runs
+      - uses: actions/cache@v4
+        with:
+          path: |
+            .shadow-cljs
+            ~/.m2/repository
+          key: shadow-cljs-${{ runner.os }}-${{ hashFiles('shadow-cljs.edn', 'package.json') }}
+          restore-keys: shadow-cljs-${{ runner.os }}-
+
+      - name: Install JS deps
+        run: pnpm install --frozen-lockfile
+
+      - name: Compile CLJS tests
+        run: pnpm exec shadow-cljs compile node-test
+
+      - name: Run CLJS tests
+        run: node target/node-test.js
+
+  cljs-lint:
+    name: cljs-lint
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - uses: actions/setup-node@v5
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install JS deps
+        run: pnpm install --frozen-lockfile
+
+      # clj-kondo ships as a native binary via the npm wrapper
+      - name: Install clj-kondo
+        run: pnpm add -g clj-kondo || npm install -g clj-kondo || true
+
+      # Populate clj-kondo cache for deps declared in shadow-cljs.edn
+      - uses: actions/cache@v4
+        with:
+          path: .clj-kondo/.cache
+          key: clj-kondo-${{ runner.os }}-${{ hashFiles('shadow-cljs.edn') }}
+          restore-keys: clj-kondo-${{ runner.os }}-
+
+      - name: clj-kondo lint
+        run: clj-kondo --lint src/proxx test/proxx

--- a/docs/ledger-event-spec.md
+++ b/docs/ledger-event-spec.md
@@ -1,0 +1,230 @@
+# Proxx Ledger Event Specification
+
+This document defines the 11 canonical ledger events used by the Proxx routing
+layer to derive session epochs, account affinity, and cache-recovery decisions.
+
+All events are immutable once written.  Mutable state (account health, epoch,
+cooldown) is derived by projection functions over the ledger — never by updating
+existing records.
+
+---
+
+## Design Principles
+
+- **Append-only.** Events are never updated or deleted.
+- **Epoch = projection.** A session–account epoch is the hash of the most recent
+  failure event for a `(session, provider, account, model)` tuple.  No counter is
+  incremented; you scan the ledger.
+- **Policy as data.** Cache TTLs, quota windows, and promotion thresholds live in
+  `cache_policy.cljs` and `projector.cljs`, not in the event handlers.
+- **Raw body preserved.** Silent-failure providers (e.g. Ollama returning 200 with
+  a quota message in the body) have their `raw_body` retained so labels can be
+  corrected or classifiers retrained without data loss.
+
+---
+
+## Epoch Semantics
+
+An **epoch** for a `(session_id, provider_id, account_id, model_id)` tuple is:
+
+```
+epoch_id = hash(event_id | ts | event_type | outcome)
+           of the most recent failure/abandonment event
+```
+
+If no failure has occurred, the epoch is the sentinel `::epoch-0`.
+
+An **affinity binding** is valid as long as `stored_epoch_id == current_epoch(ledger, tuple)`.
+When a new failure event is appended, the epoch shifts and old bindings become stale.
+
+---
+
+## Event Catalogue
+
+### 1. `session_start`
+
+First occurrence of a client providing a given harness cache key.
+
+| Field | Type | Notes |
+|---|---|---|
+| `session_id` | string | Client-visible session identity |
+| `harness_id` | string | opencode / pi / etc. |
+| `harness_cache_key` | string | What the client calls it |
+| `derived_cache_key` | string | Internal key at epoch 0 |
+| `provider_id` | string | Initial provider choice |
+| `account_id` | string | Initial account choice |
+| `model_id` | string | Initial model choice |
+
+---
+
+### 2. `empty_provider_response`
+
+HTTP call returned an empty body, or a body that could not be decoded.  Covers
+Ollama-style silent quota exhaustion (HTTP 200, quota message in body).
+
+| Field | Type | Notes |
+|---|---|---|
+| `request_id` | string | |
+| `http_status` | int | Often 200 for Ollama quota errors |
+| `raw_body` | string? | Retained for re-labelling |
+| `outcome` | RoutingOutcome | `:quota-exhausted-in-body`, `:empty-response`, etc. |
+| `label` | string? | Classifier output |
+| `label_confidence` | double? | 0..1 |
+
+---
+
+### 3. `unrecognized_response_schema`
+
+Response body was non-empty but did not match any known provider schema.
+
+| Field | Type | Notes |
+|---|---|---|
+| `request_id` | string | |
+| `http_status` | int | |
+| `raw_body` | string? | |
+| `expected_schema` | keyword | `:openai-chat`, `:anthropic-messages`, etc. |
+
+---
+
+### 4. `session_account_changed`
+
+Router switched accounts for an ongoing session.
+
+| Field | Type | Notes |
+|---|---|---|
+| `from_account_id` | string | |
+| `to_account_id` | string | |
+| `from_provider_id` | string? | |
+| `to_provider_id` | string? | |
+| `reason` | RoutingOutcome | Why we left the old account |
+| `epoch_id_before` | string | Epoch at time of switch |
+| `epoch_id_after` | string | New epoch |
+
+---
+
+### 5. `session_model_changed`
+
+Router or client changed the model mid-session.
+
+| Field | Type | Notes |
+|---|---|---|
+| `from_model_id` | string | |
+| `to_model_id` | string | |
+| `reason` | enum | `:context-overflow`, `:policy`, `:manual`, `:client-requested` |
+| `epoch_id_before` | string | |
+| `epoch_id_after` | string | |
+
+---
+
+### 6. `session_churn_detected`
+
+Client-side message pruning or compaction changed the session message array in
+a way that may break prompt cache affinity.
+
+| Field | Type | Notes |
+|---|---|---|
+| `churn_type` | enum | `:tool-call-pruning`, `:compaction`, `:client-unknown` |
+| `prefix_similarity_before` | double? | 0..1 cosine or length ratio |
+| `prefix_similarity_after` | double? | |
+| `message_count_before` | int? | |
+| `message_count_after` | int? | |
+
+---
+
+### 7. `context_overflow_detected`
+
+Practical context limit reached for `(provider, model)`.  May differ from the
+advertised limit — e.g. z.ai emits truncation signals well before the published
+context window.
+
+| Field | Type | Notes |
+|---|---|---|
+| `tokens_in` | int | |
+| `tokens_out` | int? | |
+| `advertised_context_limit` | int? | From provider catalog |
+| `observed_limit_estimate` | int? | Derived from this event |
+| `overflow_signal` | enum | `:hard-error`, `:soft-truncation`, `:empty-response`, `:provider-message` |
+| `raw_signal` | string? | Raw provider message |
+
+---
+
+### 8. `account_cooldown_initiated`
+
+| Field | Type | Notes |
+|---|---|---|
+| `reason` | CooldownReason | `:quota-short`, `:quota-weekly`, `:error-rate`, `:latency`, `:manual` |
+| `cooldown_until` | int | Epoch ms |
+| `triggering_event_id` | string? | FK to the event that caused this |
+
+---
+
+### 9. `account_cooldown_expired`
+
+| Field | Type | Notes |
+|---|---|---|
+| `cooldown_initiated_at` | int | Epoch ms |
+| `cooldown_reason` | CooldownReason | |
+
+---
+
+### 10. `quota_reset_detected`
+
+| Field | Type | Notes |
+|---|---|---|
+| `window_type` | QuotaWindowType | `:short`, `:long`, `:weekly`, `:unknown` |
+| `detected_via` | enum | `:explicit-api`, `:inferred-from-traffic`, `:manual` |
+| `tokens_available` | int? | If known |
+| `reset_at` | int? | Epoch ms |
+
+---
+
+### 11. `account_health_degraded` / `account_health_improved`
+
+| Field | Type | Notes |
+|---|---|---|
+| `health_score_before` | double | |
+| `health_score_after` | double | |
+| `degraded_threshold` / `recovery_threshold` | double | Configurable per provider |
+| `contributing_metrics` | map? | `error_rate`, `p50_latency_ms`, `p99_latency_ms`, `quota_pressure` |
+
+---
+
+## Provider Cache Config
+
+| Provider | Cache TTL | Short Quota Window | Long Quota Window |
+|---|---|---|---|
+| OpenAI | 24h | 5h | 1 week |
+| Anthropic | 24h | 1h | 30 days |
+| Ollama Cloud | 4h | 4h | 1 week |
+
+These values are defined in `proxx.ledger.projector/provider-cache-config`
+and used by `cache-recoverable?` to decide whether account A can reclaim
+affinity after having been displaced by account B.
+
+---
+
+## Quota Reset and Cache Recovery Logic
+
+Account A can re-claim affinity for a session if **all** of the following hold:
+
+1. `now - last_success_with_A < provider.cache_ttl`
+2. `now - last_failure_with_A >= provider.short_quota_window`
+3. No `session_churn_detected` or `context_overflow_detected` events occurred
+   after `last_success_with_A`
+4. Current epoch for `(session, provider, A, model)` is still valid
+
+If these conditions hold, the router may reuse the **same epoch / derived cache key**
+for account A, preserving the provider-side prompt cache.
+
+Otherwise, a new epoch begins, a new `derived_cache_key` is computed, and the
+old affinity record becomes unreachable.
+
+---
+
+## Relationship to `requests.jsonl`
+
+The existing `requests.jsonl` file captures per-request attempt data.
+The events above are **higher-level signals** derived from one or more request
+attempts, or from account/session state changes that cross request boundaries.
+
+Both logs feed the projection functions; neither replaces the other.

--- a/shadow-cljs.edn
+++ b/shadow-cljs.edn
@@ -1,0 +1,10 @@
+{:source-paths ["src" "test"]
+
+ :dependencies
+ [[metosin/malli "0.16.4"]]
+
+ :builds
+ {:node-test
+  {:target     :node-test
+   :output-to  "target/node-test.js"
+   :ns-regexp  "proxx\\..*-test$"}}}

--- a/shadow-cljs.edn
+++ b/shadow-cljs.edn
@@ -5,6 +5,6 @@
 
  :builds
  {:node-test
-  {:target     :node-test
-   :output-to  "target/node-test.js"
-   :ns-regexp  "proxx\\..*-test$"}}}
+  {:target      :node-test
+   :output-to   "target/node-test.cjs"
+   :ns-regexp   "proxx\\..*-test$"}}}

--- a/src/proxx/cache_policy.cljs
+++ b/src/proxx/cache_policy.cljs
@@ -1,0 +1,41 @@
+(ns proxx.cache-policy)
+
+;; Cache policy by entity type.
+;; Drivers are policy-blind; they consult this data via the pipeline.
+
+(def policies
+  {:provider
+   {:redis-ttl-s   300
+    :lmdb-ttl-s    3600
+    :write-through [:redis :lmdb :postgres]
+    :read-order    [:redis :lmdb :postgres]}
+
+   :provider-model
+   {:redis-ttl-s   300
+    :lmdb-ttl-s    3600
+    :write-through [:redis :lmdb :postgres]
+    :read-order    [:redis :lmdb :postgres]}
+
+   :prompt-affinity
+   {:redis-ttl-s   120
+    :lmdb-ttl-s    900
+    :write-through [:redis :lmdb :postgres]
+    :read-order    [:redis :lmdb :postgres]}
+
+   :pheromone-state
+   {:redis-ttl-s   60
+    :lmdb-ttl-s    300
+    :write-through [:redis :lmdb]
+    :read-order    [:redis :lmdb]}
+
+   :routing-policy
+   {:redis-ttl-s   600
+    :lmdb-ttl-s    7200
+    :write-through [:redis :lmdb :postgres]
+    :read-order    [:redis :lmdb :postgres]}
+
+   :affinity-policy
+   {:redis-ttl-s   600
+    :lmdb-ttl-s    7200
+    :write-through [:redis :lmdb :postgres]
+    :read-order    [:redis :lmdb :postgres]}})

--- a/src/proxx/ledger/projector.cljs
+++ b/src/proxx/ledger/projector.cljs
@@ -1,0 +1,204 @@
+(ns proxx.ledger.projector
+  (:require [clojure.string :as str]
+            [proxx.ledger.schema :as ls]))
+
+;; ── Failure event detection ───────────────────────────────────────────────────
+;; These are the event types / outcomes that advance an epoch.
+
+(def terminal-outcomes
+  #{:quota-exhausted
+    :quota-exhausted-in-body
+    :auth-failure
+    :all-strategies-exhausted
+    :empty-response
+    :unrecognized-schema})
+
+(def terminal-event-types
+  #{:empty-provider-response
+    :unrecognized-response-schema
+    :account-cooldown-initiated
+    :session-account-changed
+    :session-model-changed})
+
+(defn failure-event?
+  "Returns true if this ledger event represents a terminal / abandonment signal."
+  [event]
+  (or (terminal-event-types (:event-type event))
+      (terminal-outcomes (:outcome event))))
+
+;; ── Epoch projection ──────────────────────────────────────────────────────────
+;; An epoch is the stable identity of a (session, provider, account, model)
+;; between failure events.  Epoch-id is derived from the most recent failure
+;; event for that tuple — not an incrementing counter.
+
+(defn epoch-key
+  "Canonical tuple used to scope epoch queries."
+  [{:keys [session-id provider-id account-id model-id]}]
+  [session-id provider-id account-id model-id])
+
+(defn derive-epoch-id
+  "Returns epoch-id (string) for the most recent failure event in `events`.
+   Events must be pre-filtered to the relevant (session,provider,account,model)
+   and sorted oldest → newest.
+   Returns ::epoch-0 sentinel when no failure has occurred."
+  [events]
+  (let [last-failure (->> events
+                          (filter failure-event?)
+                          last)]
+    (if last-failure
+      ;; deterministic hash over the failure event's identity fields
+      (let [raw (str/join "|"
+                          [(:event-id last-failure)
+                           (:ts last-failure)
+                           (name (:event-type last-failure))
+                           (some-> last-failure :outcome name)])]
+        ;; In CLJS we have no built-in sha256; callers should provide a hasher.
+        ;; We store raw for now and note that the hash fn is injected.
+        raw)
+      ::epoch-0)))
+
+(defn current-epoch
+  "Given a full ledger (seq of all events) and a tuple map
+   {:session-id :provider-id :account-id :model-id},
+   return the current epoch-id."
+  [ledger tuple]
+  (let [k (epoch-key tuple)
+        relevant (->> ledger
+                      (filter #(= k (epoch-key %)))
+                      (sort-by :ts))]
+    (derive-epoch-id relevant)))
+
+(defn epoch-unchanged?
+  "Returns true when stored-epoch-id still matches the derived epoch-id
+   from the current ledger slice.  Used to validate affinity binding
+   staleness."
+  [stored-epoch-id ledger tuple]
+  (= stored-epoch-id (current-epoch ledger tuple)))
+
+;; ── Session timeline projection ───────────────────────────────────────────────
+
+(defn session-events
+  "All ledger events for a given session-id, sorted oldest → newest."
+  [ledger session-id]
+  (->> ledger
+       (filter #(= session-id (:session-id %)))
+       (sort-by :ts)))
+
+(defn last-success-at
+  "Timestamp of most recent :success outcome event for
+   (session, provider, account, model), or nil."
+  [ledger tuple]
+  (->> ledger
+       (filter #(= (epoch-key tuple) (epoch-key %)))
+       (filter #(= :success (:outcome %)))
+       (sort-by :ts)
+       last
+       :ts))
+
+(defn last-failure-at
+  "Timestamp of most recent failure event for a tuple, or nil."
+  [ledger tuple]
+  (->> ledger
+       (filter #(= (epoch-key tuple) (epoch-key %)))
+       (filter failure-event?)
+       (sort-by :ts)
+       last
+       :ts))
+
+;; ── Cache recoverability ──────────────────────────────────────────────────────
+;; Provider-level cache TTL and quota window config.
+;; These values are consulted when deciding whether to re-attach to account A
+;; after having used account B for a while.
+
+(def provider-cache-config
+  {:openai      {:cache-ttl-ms          (* 24 60 60 1000)
+                 :short-quota-window-ms (* 5  60 60 1000)
+                 :long-quota-window-ms  (* 7  24 60 60 1000)}
+   :anthropic   {:cache-ttl-ms          (* 24 60 60 1000)
+                 :short-quota-window-ms (* 1  60 60 1000)
+                 :long-quota-window-ms  (* 30 24 60 60 1000)}
+   :ollama-cloud {:cache-ttl-ms          (* 4  60 60 1000)
+                  :short-quota-window-ms (* 4  60 60 1000)
+                  :long-quota-window-ms  (* 7  24 60 60 1000)}})
+
+(defn cache-recoverable?
+  "Returns true when:
+   - we are still within the provider's cache TTL since last success with A, and
+   - enough time has passed since the abandonment for the short quota window to reset.
+   If session churn or context overflow occurred after last-success, returns false
+   regardless — the cache prefix is likely gone."
+  [ledger tuple provider-id now-ms]
+  (let [cfg            (get provider-cache-config (keyword provider-id))
+        success-ts     (last-success-at ledger tuple)
+        failure-ts     (last-failure-at ledger tuple)
+        churn-after?   (->> (session-events ledger (:session-id tuple))
+                            (filter #(#{:session-churn-detected
+                                        :context-overflow-detected} (:event-type %)))
+                            (filter #(> (:ts %) (or success-ts 0)))
+                            seq
+                            boolean)]
+    (and cfg
+         success-ts
+         failure-ts
+         (not churn-after?)
+         ;; still inside provider cache TTL
+         (< (- now-ms success-ts) (:cache-ttl-ms cfg))
+         ;; short quota window has had time to reset
+         (>= (- now-ms failure-ts) (:short-quota-window-ms cfg)))))
+
+;; ── Prefix similarity ─────────────────────────────────────────────────────────
+;; Simple token-count heuristic: length of common prefix / length of original.
+;; Replace with vector similarity when embeddings are available.
+
+(defn prefix-similarity
+  "Returns 0..1 similarity between two message-count snapshots.
+   This is a rough heuristic; replace with embedding cosine similarity later."
+  [count-at-success count-now]
+  (if (or (nil? count-at-success) (zero? count-at-success) (nil? count-now))
+    0.0
+    (/ (min count-at-success count-now)
+       (max count-at-success count-now))))
+
+;; ── Scoring metrics projection ────────────────────────────────────────────────
+;; Aggregates all relevant ledger signals into a metric map suitable
+;; for the router scoring pipeline (proxx.processor/compute-score).
+
+(defn project-account-metrics
+  "Returns a metric map for (session, provider, account, model) at `now-ms`.
+   These feed into the Boltzmann scoring pipeline alongside pheromone / health."
+  [ledger tuple now-ms]
+  (let [provider-id        (:provider-id tuple)
+        relevant           (->> ledger
+                                (filter #(= (epoch-key tuple) (epoch-key %)))
+                                (sort-by :ts))
+        success-ts         (last-success-at ledger tuple)
+        failure-ts         (last-failure-at ledger tuple)
+        cooldown-active?   (->> relevant
+                                (filter #(= :account-cooldown-initiated (:event-type %)))
+                                (some (fn [ev]
+                                        (> (:cooldown-until ev 0) now-ms))))
+        cooldown-expired?  (boolean
+                            (->> relevant
+                                 (filter #(= :account-cooldown-expired (:event-type %)))
+                                 (filter #(> (:ts %) (or failure-ts 0)))
+                                 seq))
+        quota-reset?       (boolean
+                            (->> relevant
+                                 (filter #(= :quota-reset-detected (:event-type %)))
+                                 (filter #(> (:ts %) (or failure-ts 0)))
+                                 seq))
+        context-overflows  (->> relevant
+                                (filter #(= :context-overflow-detected (:event-type %)))
+                                count)
+        churn-events       (->> relevant
+                                (filter #(= :session-churn-detected (:event-type %)))
+                                count)]
+    {:cooldown-active?     (boolean cooldown-active?)
+     :cooldown-expired?    cooldown-expired?
+     :quota-reset?         quota-reset?
+     :time-since-last-success-ms (when success-ts (- now-ms success-ts))
+     :time-since-last-failure-ms (when failure-ts (- now-ms failure-ts))
+     :cache-recoverable?   (cache-recoverable? ledger tuple provider-id now-ms)
+     :context-overflow-count context-overflows
+     :churn-count          churn-events
+     :epoch-id             (current-epoch ledger tuple)}))

--- a/src/proxx/ledger/projector.cljs
+++ b/src/proxx/ledger/projector.cljs
@@ -1,9 +1,5 @@
 (ns proxx.ledger.projector
-  (:require [clojure.string :as str]
-            [proxx.ledger.schema :as ls]))
-
-;; ── Failure event detection ───────────────────────────────────────────────────
-;; These are the event types / outcomes that advance an epoch.
+  (:require [clojure.string :as str]))
 
 (def terminal-outcomes
   #{:quota-exhausted
@@ -26,11 +22,6 @@
   (or (terminal-event-types (:event-type event))
       (terminal-outcomes (:outcome event))))
 
-;; ── Epoch projection ──────────────────────────────────────────────────────────
-;; An epoch is the stable identity of a (session, provider, account, model)
-;; between failure events.  Epoch-id is derived from the most recent failure
-;; event for that tuple — not an incrementing counter.
-
 (defn epoch-key
   "Canonical tuple used to scope epoch queries."
   [{:keys [session-id provider-id account-id model-id]}]
@@ -39,26 +30,22 @@
 (defn derive-epoch-id
   "Returns epoch-id (string) for the most recent failure event in `events`.
    Events must be pre-filtered to the relevant (session,provider,account,model)
-   and sorted oldest → newest.
+   and sorted oldest->newest.
    Returns ::epoch-0 sentinel when no failure has occurred."
   [events]
   (let [last-failure (->> events
                           (filter failure-event?)
                           last)]
     (if last-failure
-      ;; deterministic hash over the failure event's identity fields
-      (let [raw (str/join "|"
-                          [(:event-id last-failure)
-                           (:ts last-failure)
-                           (name (:event-type last-failure))
-                           (some-> last-failure :outcome name)])]
-        ;; In CLJS we have no built-in sha256; callers should provide a hasher.
-        ;; We store raw for now and note that the hash fn is injected.
-        raw)
+      (str/join "|"
+                [(:event-id last-failure)
+                 (:ts last-failure)
+                 (name (:event-type last-failure))
+                 (some-> last-failure :outcome name)])
       ::epoch-0)))
 
 (defn current-epoch
-  "Given a full ledger (seq of all events) and a tuple map
+  "Given a full ledger and a tuple map
    {:session-id :provider-id :account-id :model-id},
    return the current epoch-id."
   [ledger tuple]
@@ -70,23 +57,19 @@
 
 (defn epoch-unchanged?
   "Returns true when stored-epoch-id still matches the derived epoch-id
-   from the current ledger slice.  Used to validate affinity binding
-   staleness."
+   from the current ledger slice."
   [stored-epoch-id ledger tuple]
   (= stored-epoch-id (current-epoch ledger tuple)))
 
-;; ── Session timeline projection ───────────────────────────────────────────────
-
 (defn session-events
-  "All ledger events for a given session-id, sorted oldest → newest."
+  "All ledger events for a given session-id, sorted oldest->newest."
   [ledger session-id]
   (->> ledger
        (filter #(= session-id (:session-id %)))
        (sort-by :ts)))
 
 (defn last-success-at
-  "Timestamp of most recent :success outcome event for
-   (session, provider, account, model), or nil."
+  "Timestamp of most recent :success outcome event for a tuple, or nil."
   [ledger tuple]
   (->> ledger
        (filter #(= (epoch-key tuple) (epoch-key %)))
@@ -105,100 +88,79 @@
        last
        :ts))
 
-;; ── Cache recoverability ──────────────────────────────────────────────────────
-;; Provider-level cache TTL and quota window config.
-;; These values are consulted when deciding whether to re-attach to account A
-;; after having used account B for a while.
-
 (def provider-cache-config
-  {:openai      {:cache-ttl-ms          (* 24 60 60 1000)
-                 :short-quota-window-ms (* 5  60 60 1000)
-                 :long-quota-window-ms  (* 7  24 60 60 1000)}
-   :anthropic   {:cache-ttl-ms          (* 24 60 60 1000)
-                 :short-quota-window-ms (* 1  60 60 1000)
-                 :long-quota-window-ms  (* 30 24 60 60 1000)}
+  {:openai       {:cache-ttl-ms          (* 24 60 60 1000)
+                  :short-quota-window-ms (* 5  60 60 1000)
+                  :long-quota-window-ms  (* 7  24 60 60 1000)}
+   :anthropic    {:cache-ttl-ms          (* 24 60 60 1000)
+                  :short-quota-window-ms (* 1  60 60 1000)
+                  :long-quota-window-ms  (* 30 24 60 60 1000)}
    :ollama-cloud {:cache-ttl-ms          (* 4  60 60 1000)
                   :short-quota-window-ms (* 4  60 60 1000)
                   :long-quota-window-ms  (* 7  24 60 60 1000)}})
 
 (defn cache-recoverable?
-  "Returns true when:
-   - we are still within the provider's cache TTL since last success with A, and
-   - enough time has passed since the abandonment for the short quota window to reset.
-   If session churn or context overflow occurred after last-success, returns false
-   regardless — the cache prefix is likely gone."
+  "Returns true when within provider cache TTL since last success AND
+   enough time has elapsed since failure for the short quota window to reset.
+   Returns false if churn or context overflow occurred after last success."
   [ledger tuple provider-id now-ms]
-  (let [cfg            (get provider-cache-config (keyword provider-id))
-        success-ts     (last-success-at ledger tuple)
-        failure-ts     (last-failure-at ledger tuple)
-        churn-after?   (->> (session-events ledger (:session-id tuple))
-                            (filter #(#{:session-churn-detected
-                                        :context-overflow-detected} (:event-type %)))
-                            (filter #(> (:ts %) (or success-ts 0)))
-                            seq
-                            boolean)]
-    (and cfg
-         success-ts
-         failure-ts
-         (not churn-after?)
-         ;; still inside provider cache TTL
-         (< (- now-ms success-ts) (:cache-ttl-ms cfg))
-         ;; short quota window has had time to reset
-         (>= (- now-ms failure-ts) (:short-quota-window-ms cfg)))))
-
-;; ── Prefix similarity ─────────────────────────────────────────────────────────
-;; Simple token-count heuristic: length of common prefix / length of original.
-;; Replace with vector similarity when embeddings are available.
+  (let [cfg          (get provider-cache-config (keyword provider-id))
+        success-ts   (last-success-at ledger tuple)
+        failure-ts   (last-failure-at ledger tuple)
+        churn-after? (->> (session-events ledger (:session-id tuple))
+                          (filter #(#{:session-churn-detected
+                                      :context-overflow-detected} (:event-type %)))
+                          (filter #(> (:ts %) (or success-ts 0)))
+                          seq
+                          boolean)]
+    (boolean
+     (and cfg
+          success-ts
+          failure-ts
+          (not churn-after?)
+          (< (- now-ms success-ts) (:cache-ttl-ms cfg))
+          (>= (- now-ms failure-ts) (:short-quota-window-ms cfg))))))
 
 (defn prefix-similarity
-  "Returns 0..1 similarity between two message-count snapshots.
-   This is a rough heuristic; replace with embedding cosine similarity later."
+  "Returns 0..1 similarity between two message-count snapshots."
   [count-at-success count-now]
   (if (or (nil? count-at-success) (zero? count-at-success) (nil? count-now))
     0.0
     (/ (min count-at-success count-now)
        (max count-at-success count-now))))
 
-;; ── Scoring metrics projection ────────────────────────────────────────────────
-;; Aggregates all relevant ledger signals into a metric map suitable
-;; for the router scoring pipeline (proxx.processor/compute-score).
-
 (defn project-account-metrics
-  "Returns a metric map for (session, provider, account, model) at `now-ms`.
-   These feed into the Boltzmann scoring pipeline alongside pheromone / health."
+  "Aggregates ledger signals into a metric map for
+   (session, provider, account, model) at now-ms."
   [ledger tuple now-ms]
-  (let [provider-id        (:provider-id tuple)
-        relevant           (->> ledger
-                                (filter #(= (epoch-key tuple) (epoch-key %)))
-                                (sort-by :ts))
-        success-ts         (last-success-at ledger tuple)
-        failure-ts         (last-failure-at ledger tuple)
-        cooldown-active?   (->> relevant
-                                (filter #(= :account-cooldown-initiated (:event-type %)))
-                                (some (fn [ev]
-                                        (> (:cooldown-until ev 0) now-ms))))
-        cooldown-expired?  (boolean
-                            (->> relevant
-                                 (filter #(= :account-cooldown-expired (:event-type %)))
-                                 (filter #(> (:ts %) (or failure-ts 0)))
-                                 seq))
-        quota-reset?       (boolean
-                            (->> relevant
-                                 (filter #(= :quota-reset-detected (:event-type %)))
-                                 (filter #(> (:ts %) (or failure-ts 0)))
-                                 seq))
-        context-overflows  (->> relevant
-                                (filter #(= :context-overflow-detected (:event-type %)))
-                                count)
-        churn-events       (->> relevant
-                                (filter #(= :session-churn-detected (:event-type %)))
-                                count)]
-    {:cooldown-active?     (boolean cooldown-active?)
-     :cooldown-expired?    cooldown-expired?
-     :quota-reset?         quota-reset?
-     :time-since-last-success-ms (when success-ts (- now-ms success-ts))
-     :time-since-last-failure-ms (when failure-ts (- now-ms failure-ts))
-     :cache-recoverable?   (cache-recoverable? ledger tuple provider-id now-ms)
-     :context-overflow-count context-overflows
-     :churn-count          churn-events
-     :epoch-id             (current-epoch ledger tuple)}))
+  (let [provider-id      (:provider-id tuple)
+        relevant         (->> ledger
+                              (filter #(= (epoch-key tuple) (epoch-key %)))
+                              (sort-by :ts))
+        success-ts       (last-success-at ledger tuple)
+        failure-ts       (last-failure-at ledger tuple)
+        cooldown-active? (some (fn [ev]
+                                 (and (= :account-cooldown-initiated (:event-type ev))
+                                      (> (:cooldown-until ev 0) now-ms)))
+                               relevant)
+        cooldown-expired? (boolean
+                           (some (fn [ev]
+                                   (and (= :account-cooldown-expired (:event-type ev))
+                                        (> (:ts ev) (or failure-ts 0))))
+                                 relevant))
+        quota-reset?      (boolean
+                           (some (fn [ev]
+                                   (and (= :quota-reset-detected (:event-type ev))
+                                        (> (:ts ev) (or failure-ts 0))))
+                                 relevant))
+        context-overflows (count (filter #(= :context-overflow-detected (:event-type %)) relevant))
+        churn-events      (count (filter #(= :session-churn-detected (:event-type %)) relevant))]
+    {:cooldown-active?              (boolean cooldown-active?)
+     :cooldown-expired?             cooldown-expired?
+     :quota-reset?                  quota-reset?
+     :time-since-last-success-ms    (when success-ts (- now-ms success-ts))
+     :time-since-last-failure-ms    (when failure-ts (- now-ms failure-ts))
+     :cache-recoverable?            (cache-recoverable? ledger tuple provider-id now-ms)
+     :context-overflow-count        context-overflows
+     :churn-count                   churn-events
+     :epoch-id                      (current-epoch ledger tuple)}))

--- a/src/proxx/ledger/schema.cljs
+++ b/src/proxx/ledger/schema.cljs
@@ -2,20 +2,16 @@
   (:require [malli.core :as m]
             [proxx.schema :as s]))
 
-;; ── Shared primitives ────────────────────────────────────────────────────────
-
 (def SessionId  :string)
 (def HarnessId  :string)
 (def RequestId  :string)
-(def EpochId    :string)  ;; hash of most recent failure event for a given (session,provider,account,model)
-
-;; ── Outcome vocabulary ───────────────────────────────────────────────────────
+(def EpochId    :string)
 
 (def RoutingOutcome
   [:enum
    :success
    :quota-exhausted
-   :quota-exhausted-in-body   ;; e.g. Ollama 200 with quota message
+   :quota-exhausted-in-body
    :rate-limited
    :timeout
    :server-error
@@ -37,22 +33,16 @@
 (def HealthThresholdType
   [:enum :degraded :recovered])
 
-;; ── Base event fields ────────────────────────────────────────────────────────
-;; Every ledger event carries these.
-
 (def BaseEvent
   [:map
    [:event-id     :string]
    [:event-type   :keyword]
-   [:ts           :int]          ;; epoch ms
+   [:ts           :int]
    [:session-id   {:optional true} SessionId]
    [:provider-id  {:optional true} s/ProviderId]
    [:account-id   {:optional true} s/AccountId]
    [:model-id     {:optional true} s/ModelId]
    [:provenance   {:optional true} s/Provenance]])
-
-;; ── 1. Session start ─────────────────────────────────────────────────────────
-;; First occurrence of a client providing a given cache key.
 
 (def SessionStartEvent
   [:merge BaseEvent
@@ -60,14 +50,11 @@
     [:event-type          [:= :session-start]]
     [:session-id          SessionId]
     [:harness-id          HarnessId]
-    [:harness-cache-key   :string]   ;; what the client calls it
-    [:derived-cache-key   :string]   ;; our computed internal key at epoch 0
+    [:harness-cache-key   :string]
+    [:derived-cache-key   :string]
     [:provider-id         s/ProviderId]
     [:account-id          s/AccountId]
     [:model-id            s/ModelId]]])
-
-;; ── 2. Empty / unrecognized provider response ────────────────────────────────
-;; Covers Ollama-style silent quota exhaustion (200 + quota message in body).
 
 (def EmptyProviderResponseEvent
   [:merge BaseEvent
@@ -75,9 +62,9 @@
     [:event-type      [:= :empty-provider-response]]
     [:request-id      RequestId]
     [:http-status     :int]
-    [:raw-body        {:optional true} :string]   ;; kept for re-labelling
+    [:raw-body        {:optional true} :string]
     [:outcome         RoutingOutcome]
-    [:label           {:optional true} :string]   ;; classifier output
+    [:label           {:optional true} :string]
     [:label-confidence {:optional true} :double]]])
 
 (def UnrecognizedSchemaEvent
@@ -88,8 +75,6 @@
     [:http-status  :int]
     [:raw-body     {:optional true} :string]
     [:expected-schema :keyword]]])
-
-;; ── 3. Session account changed ───────────────────────────────────────────────
 
 (def SessionAccountChangedEvent
   [:merge BaseEvent
@@ -104,8 +89,6 @@
     [:epoch-id-before  EpochId]
     [:epoch-id-after   EpochId]]])
 
-;; ── 4. Session model changed ─────────────────────────────────────────────────
-
 (def SessionModelChangedEvent
   [:merge BaseEvent
    [:map
@@ -117,23 +100,16 @@
     [:epoch-id-before EpochId]
     [:epoch-id-after  EpochId]]])
 
-;; ── 5. Session churn detected ────────────────────────────────────────────────
-;; Client-side tool-call pruning or compaction broke affinity.
-
 (def SessionChurnDetectedEvent
   [:merge BaseEvent
    [:map
     [:event-type            [:= :session-churn-detected]]
     [:session-id            SessionId]
     [:churn-type            ChurnType]
-    [:prefix-similarity-before {:optional true} :double]   ;; 0..1
+    [:prefix-similarity-before {:optional true} :double]
     [:prefix-similarity-after  {:optional true} :double]
     [:message-count-before  {:optional true} :int]
     [:message-count-after   {:optional true} :int]]])
-
-;; ── 6. Context overflow detected ────────────────────────────────────────────
-;; Hit practical context limit for (provider, model).
-;; Distinct from advertised limit — captures actual observed behavior.
 
 (def ContextOverflowDetectedEvent
   [:merge BaseEvent
@@ -147,17 +123,13 @@
     [:overflow-signal          [:enum :hard-error :soft-truncation :empty-response :provider-message]]
     [:raw-signal               {:optional true} :string]]])
 
-;; ── 7. Account cooldown initiated ───────────────────────────────────────────
-
 (def AccountCooldownInitiatedEvent
   [:merge BaseEvent
    [:map
     [:event-type       [:= :account-cooldown-initiated]]
     [:reason           CooldownReason]
-    [:cooldown-until   :int]       ;; epoch ms — expected expiry
+    [:cooldown-until   :int]
     [:triggering-event-id {:optional true} :string]]])
-
-;; ── 8. Account cooldown expired ─────────────────────────────────────────────
 
 (def AccountCooldownExpiredEvent
   [:merge BaseEvent
@@ -165,8 +137,6 @@
     [:event-type        [:= :account-cooldown-expired]]
     [:cooldown-initiated-at :int]
     [:cooldown-reason   CooldownReason]]])
-
-;; ── 9. Quota reset detected ─────────────────────────────────────────────────
 
 (def QuotaResetDetectedEvent
   [:merge BaseEvent
@@ -176,8 +146,6 @@
     [:detected-via    [:enum :explicit-api :inferred-from-traffic :manual]]
     [:tokens-available {:optional true} :int]
     [:reset-at        {:optional true} :int]]])
-
-;; ── 10. Account health degraded ─────────────────────────────────────────────
 
 (def AccountHealthDegradedEvent
   [:merge BaseEvent
@@ -193,8 +161,6 @@
       [:p99-latency-ms {:optional true} :double]
       [:quota-pressure {:optional true} :double]]]]])
 
-;; ── 11. Account health improved ─────────────────────────────────────────────
-
 (def AccountHealthImprovedEvent
   [:merge BaseEvent
    [:map
@@ -208,9 +174,6 @@
       [:p50-latency-ms {:optional true} :double]
       [:p99-latency-ms {:optional true} :double]
       [:quota-pressure {:optional true} :double]]]]])
-
-;; ── Union / dispatch ─────────────────────────────────────────────────────────
-;; All ledger events as a tagged union, dispatch on :event-type.
 
 (def LedgerEvent
   [:multi {:dispatch :event-type}
@@ -241,3 +204,7 @@
    :ledger/quota-reset              QuotaResetDetectedEvent
    :ledger/health-degraded          AccountHealthDegradedEvent
    :ledger/health-improved          AccountHealthImprovedEvent})
+
+;; Force malli compilation at load time to surface schema errors early.
+(def _validate-registry
+  (m/schema [:map-of :keyword :any]))

--- a/src/proxx/ledger/schema.cljs
+++ b/src/proxx/ledger/schema.cljs
@@ -2,10 +2,14 @@
   (:require [malli.core :as m]
             [proxx.schema :as s]))
 
-(def SessionId  :string)
-(def HarnessId  :string)
-(def RequestId  :string)
-(def EpochId    :string)
+;; ── Shared primitives ────────────────────────────────────────────────────────
+
+(def SessionId :string)
+(def HarnessId :string)
+(def RequestId :string)
+(def EpochId   :string)
+
+;; ── Outcome vocabulary ───────────────────────────────────────────────────────
 
 (def RoutingOutcome
   [:enum
@@ -21,65 +25,67 @@
    :unrecognized-schema
    :all-strategies-exhausted])
 
-(def QuotaWindowType
-  [:enum :short :long :weekly :unknown])
+(def QuotaWindowType  [:enum :short :long :weekly :unknown])
+(def ChurnType        [:enum :tool-call-pruning :compaction :client-unknown])
+(def CooldownReason   [:enum :quota-short :quota-weekly :error-rate :latency :manual])
 
-(def ChurnType
-  [:enum :tool-call-pruning :compaction :client-unknown])
+;; ── Base event fields (inlined into every event schema) ──────────────────────
+;; :merge is not available in CLJS malli without a custom registry.
+;; We inline the common fields directly into each event map instead.
 
-(def CooldownReason
-  [:enum :quota-short :quota-weekly :error-rate :latency :manual])
+(def ^:private base-fields
+  [[:event-id    :string]
+   [:event-type  :keyword]
+   [:ts          :int]
+   [:session-id  {:optional true} SessionId]
+   [:provider-id {:optional true} s/ProviderId]
+   [:account-id  {:optional true} s/AccountId]
+   [:model-id    {:optional true} s/ModelId]
+   [:provenance  {:optional true} s/Provenance]])
 
-(def HealthThresholdType
-  [:enum :degraded :recovered])
+(defn- event-map
+  "Builds a [:map ...] schema from base-fields plus extra-fields."
+  [extra-fields]
+  (into [:map] (concat base-fields extra-fields)))
 
-(def BaseEvent
-  [:map
-   [:event-id     :string]
-   [:event-type   :keyword]
-   [:ts           :int]
-   [:session-id   {:optional true} SessionId]
-   [:provider-id  {:optional true} s/ProviderId]
-   [:account-id   {:optional true} s/AccountId]
-   [:model-id     {:optional true} s/ModelId]
-   [:provenance   {:optional true} s/Provenance]])
+;; ── 1. Session start ─────────────────────────────────────────────────────────
 
 (def SessionStartEvent
-  [:merge BaseEvent
-   [:map
-    [:event-type          [:= :session-start]]
-    [:session-id          SessionId]
-    [:harness-id          HarnessId]
-    [:harness-cache-key   :string]
-    [:derived-cache-key   :string]
-    [:provider-id         s/ProviderId]
-    [:account-id          s/AccountId]
-    [:model-id            s/ModelId]]])
+  (event-map
+   [[:event-type        [:= :session-start]]
+    [:session-id        SessionId]
+    [:harness-id        HarnessId]
+    [:harness-cache-key :string]
+    [:derived-cache-key :string]
+    [:provider-id       s/ProviderId]
+    [:account-id        s/AccountId]
+    [:model-id          s/ModelId]]))
+
+;; ── 2. Empty / unrecognized provider response ─────────────────────────────────
 
 (def EmptyProviderResponseEvent
-  [:merge BaseEvent
-   [:map
-    [:event-type      [:= :empty-provider-response]]
+  (event-map
+   [[:event-type       [:= :empty-provider-response]]
+    [:request-id       RequestId]
+    [:http-status      :int]
+    [:raw-body         {:optional true} :string]
+    [:outcome          RoutingOutcome]
+    [:label            {:optional true} :string]
+    [:label-confidence {:optional true} :double]]))
+
+(def UnrecognizedSchemaEvent
+  (event-map
+   [[:event-type      [:= :unrecognized-response-schema]]
     [:request-id      RequestId]
     [:http-status     :int]
     [:raw-body        {:optional true} :string]
-    [:outcome         RoutingOutcome]
-    [:label           {:optional true} :string]
-    [:label-confidence {:optional true} :double]]])
+    [:expected-schema :keyword]]))
 
-(def UnrecognizedSchemaEvent
-  [:merge BaseEvent
-   [:map
-    [:event-type   [:= :unrecognized-response-schema]]
-    [:request-id   RequestId]
-    [:http-status  :int]
-    [:raw-body     {:optional true} :string]
-    [:expected-schema :keyword]]])
+;; ── 3. Session account changed ───────────────────────────────────────────────
 
 (def SessionAccountChangedEvent
-  [:merge BaseEvent
-   [:map
-    [:event-type       [:= :session-account-changed]]
+  (event-map
+   [[:event-type       [:= :session-account-changed]]
     [:session-id       SessionId]
     [:from-account-id  s/AccountId]
     [:to-account-id    s/AccountId]
@@ -87,93 +93,103 @@
     [:to-provider-id   {:optional true} s/ProviderId]
     [:reason           RoutingOutcome]
     [:epoch-id-before  EpochId]
-    [:epoch-id-after   EpochId]]])
+    [:epoch-id-after   EpochId]]))
+
+;; ── 4. Session model changed ─────────────────────────────────────────────────
 
 (def SessionModelChangedEvent
-  [:merge BaseEvent
-   [:map
-    [:event-type     [:= :session-model-changed]]
-    [:session-id     SessionId]
-    [:from-model-id  s/ModelId]
-    [:to-model-id    s/ModelId]
-    [:reason         [:enum :context-overflow :policy :manual :client-requested]]
+  (event-map
+   [[:event-type      [:= :session-model-changed]]
+    [:session-id      SessionId]
+    [:from-model-id   s/ModelId]
+    [:to-model-id     s/ModelId]
+    [:reason          [:enum :context-overflow :policy :manual :client-requested]]
     [:epoch-id-before EpochId]
-    [:epoch-id-after  EpochId]]])
+    [:epoch-id-after  EpochId]]))
+
+;; ── 5. Session churn detected ────────────────────────────────────────────────
 
 (def SessionChurnDetectedEvent
-  [:merge BaseEvent
-   [:map
-    [:event-type            [:= :session-churn-detected]]
-    [:session-id            SessionId]
-    [:churn-type            ChurnType]
+  (event-map
+   [[:event-type               [:= :session-churn-detected]]
+    [:session-id               SessionId]
+    [:churn-type               ChurnType]
     [:prefix-similarity-before {:optional true} :double]
     [:prefix-similarity-after  {:optional true} :double]
-    [:message-count-before  {:optional true} :int]
-    [:message-count-after   {:optional true} :int]]])
+    [:message-count-before     {:optional true} :int]
+    [:message-count-after      {:optional true} :int]]))
+
+;; ── 6. Context overflow detected ─────────────────────────────────────────────
 
 (def ContextOverflowDetectedEvent
-  [:merge BaseEvent
-   [:map
-    [:event-type               [:= :context-overflow-detected]]
+  (event-map
+   [[:event-type               [:= :context-overflow-detected]]
     [:session-id               SessionId]
     [:tokens-in                :int]
     [:tokens-out               {:optional true} :int]
     [:advertised-context-limit {:optional true} :int]
     [:observed-limit-estimate  {:optional true} :int]
     [:overflow-signal          [:enum :hard-error :soft-truncation :empty-response :provider-message]]
-    [:raw-signal               {:optional true} :string]]])
+    [:raw-signal               {:optional true} :string]]))
+
+;; ── 7. Account cooldown initiated ────────────────────────────────────────────
 
 (def AccountCooldownInitiatedEvent
-  [:merge BaseEvent
-   [:map
-    [:event-type       [:= :account-cooldown-initiated]]
-    [:reason           CooldownReason]
-    [:cooldown-until   :int]
-    [:triggering-event-id {:optional true} :string]]])
+  (event-map
+   [[:event-type          [:= :account-cooldown-initiated]]
+    [:reason              CooldownReason]
+    [:cooldown-until      :int]
+    [:triggering-event-id {:optional true} :string]]))
+
+;; ── 8. Account cooldown expired ──────────────────────────────────────────────
 
 (def AccountCooldownExpiredEvent
-  [:merge BaseEvent
-   [:map
-    [:event-type        [:= :account-cooldown-expired]]
+  (event-map
+   [[:event-type           [:= :account-cooldown-expired]]
     [:cooldown-initiated-at :int]
-    [:cooldown-reason   CooldownReason]]])
+    [:cooldown-reason       CooldownReason]]))
+
+;; ── 9. Quota reset detected ──────────────────────────────────────────────────
 
 (def QuotaResetDetectedEvent
-  [:merge BaseEvent
-   [:map
-    [:event-type      [:= :quota-reset-detected]]
-    [:window-type     QuotaWindowType]
-    [:detected-via    [:enum :explicit-api :inferred-from-traffic :manual]]
+  (event-map
+   [[:event-type       [:= :quota-reset-detected]]
+    [:window-type      QuotaWindowType]
+    [:detected-via     [:enum :explicit-api :inferred-from-traffic :manual]]
     [:tokens-available {:optional true} :int]
-    [:reset-at        {:optional true} :int]]])
+    [:reset-at         {:optional true} :int]]))
+
+;; ── 10. Account health degraded ──────────────────────────────────────────────
 
 (def AccountHealthDegradedEvent
-  [:merge BaseEvent
-   [:map
-    [:event-type          [:= :account-health-degraded]]
-    [:health-score-before :double]
-    [:health-score-after  :double]
-    [:degraded-threshold  :double]
+  (event-map
+   [[:event-type           [:= :account-health-degraded]]
+    [:health-score-before  :double]
+    [:health-score-after   :double]
+    [:degraded-threshold   :double]
     [:contributing-metrics {:optional true}
      [:map
-      [:error-rate    {:optional true} :double]
+      [:error-rate     {:optional true} :double]
       [:p50-latency-ms {:optional true} :double]
       [:p99-latency-ms {:optional true} :double]
-      [:quota-pressure {:optional true} :double]]]]])
+      [:quota-pressure {:optional true} :double]]]]))
+
+;; ── 11. Account health improved ──────────────────────────────────────────────
 
 (def AccountHealthImprovedEvent
-  [:merge BaseEvent
-   [:map
-    [:event-type           [:= :account-health-improved]]
+  (event-map
+   [[:event-type           [:= :account-health-improved]]
     [:health-score-before  :double]
     [:health-score-after   :double]
     [:recovery-threshold   :double]
     [:contributing-metrics {:optional true}
      [:map
-      [:error-rate    {:optional true} :double]
+      [:error-rate     {:optional true} :double]
       [:p50-latency-ms {:optional true} :double]
       [:p99-latency-ms {:optional true} :double]
-      [:quota-pressure {:optional true} :double]]]]])
+      [:quota-pressure {:optional true} :double]]]]))
+
+;; ── Union / dispatch ─────────────────────────────────────────────────────────
 
 (def LedgerEvent
   [:multi {:dispatch :event-type}
@@ -205,6 +221,5 @@
    :ledger/health-degraded          AccountHealthDegradedEvent
    :ledger/health-improved          AccountHealthImprovedEvent})
 
-;; Force malli compilation at load time to surface schema errors early.
-(def _validate-registry
-  (m/schema [:map-of :keyword :any]))
+;; Validate registry compiles cleanly at load time.
+(def _check (m/schema [:map-of :keyword :any]))

--- a/src/proxx/ledger/schema.cljs
+++ b/src/proxx/ledger/schema.cljs
@@ -1,0 +1,243 @@
+(ns proxx.ledger.schema
+  (:require [malli.core :as m]
+            [proxx.schema :as s]))
+
+;; ── Shared primitives ────────────────────────────────────────────────────────
+
+(def SessionId  :string)
+(def HarnessId  :string)
+(def RequestId  :string)
+(def EpochId    :string)  ;; hash of most recent failure event for a given (session,provider,account,model)
+
+;; ── Outcome vocabulary ───────────────────────────────────────────────────────
+
+(def RoutingOutcome
+  [:enum
+   :success
+   :quota-exhausted
+   :quota-exhausted-in-body   ;; e.g. Ollama 200 with quota message
+   :rate-limited
+   :timeout
+   :server-error
+   :auth-failure
+   :invalid-request
+   :empty-response
+   :unrecognized-schema
+   :all-strategies-exhausted])
+
+(def QuotaWindowType
+  [:enum :short :long :weekly :unknown])
+
+(def ChurnType
+  [:enum :tool-call-pruning :compaction :client-unknown])
+
+(def CooldownReason
+  [:enum :quota-short :quota-weekly :error-rate :latency :manual])
+
+(def HealthThresholdType
+  [:enum :degraded :recovered])
+
+;; ── Base event fields ────────────────────────────────────────────────────────
+;; Every ledger event carries these.
+
+(def BaseEvent
+  [:map
+   [:event-id     :string]
+   [:event-type   :keyword]
+   [:ts           :int]          ;; epoch ms
+   [:session-id   {:optional true} SessionId]
+   [:provider-id  {:optional true} s/ProviderId]
+   [:account-id   {:optional true} s/AccountId]
+   [:model-id     {:optional true} s/ModelId]
+   [:provenance   {:optional true} s/Provenance]])
+
+;; ── 1. Session start ─────────────────────────────────────────────────────────
+;; First occurrence of a client providing a given cache key.
+
+(def SessionStartEvent
+  [:merge BaseEvent
+   [:map
+    [:event-type          [:= :session-start]]
+    [:session-id          SessionId]
+    [:harness-id          HarnessId]
+    [:harness-cache-key   :string]   ;; what the client calls it
+    [:derived-cache-key   :string]   ;; our computed internal key at epoch 0
+    [:provider-id         s/ProviderId]
+    [:account-id          s/AccountId]
+    [:model-id            s/ModelId]]])
+
+;; ── 2. Empty / unrecognized provider response ────────────────────────────────
+;; Covers Ollama-style silent quota exhaustion (200 + quota message in body).
+
+(def EmptyProviderResponseEvent
+  [:merge BaseEvent
+   [:map
+    [:event-type      [:= :empty-provider-response]]
+    [:request-id      RequestId]
+    [:http-status     :int]
+    [:raw-body        {:optional true} :string]   ;; kept for re-labelling
+    [:outcome         RoutingOutcome]
+    [:label           {:optional true} :string]   ;; classifier output
+    [:label-confidence {:optional true} :double]]])
+
+(def UnrecognizedSchemaEvent
+  [:merge BaseEvent
+   [:map
+    [:event-type   [:= :unrecognized-response-schema]]
+    [:request-id   RequestId]
+    [:http-status  :int]
+    [:raw-body     {:optional true} :string]
+    [:expected-schema :keyword]]])
+
+;; ── 3. Session account changed ───────────────────────────────────────────────
+
+(def SessionAccountChangedEvent
+  [:merge BaseEvent
+   [:map
+    [:event-type       [:= :session-account-changed]]
+    [:session-id       SessionId]
+    [:from-account-id  s/AccountId]
+    [:to-account-id    s/AccountId]
+    [:from-provider-id {:optional true} s/ProviderId]
+    [:to-provider-id   {:optional true} s/ProviderId]
+    [:reason           RoutingOutcome]
+    [:epoch-id-before  EpochId]
+    [:epoch-id-after   EpochId]]])
+
+;; ── 4. Session model changed ─────────────────────────────────────────────────
+
+(def SessionModelChangedEvent
+  [:merge BaseEvent
+   [:map
+    [:event-type     [:= :session-model-changed]]
+    [:session-id     SessionId]
+    [:from-model-id  s/ModelId]
+    [:to-model-id    s/ModelId]
+    [:reason         [:enum :context-overflow :policy :manual :client-requested]]
+    [:epoch-id-before EpochId]
+    [:epoch-id-after  EpochId]]])
+
+;; ── 5. Session churn detected ────────────────────────────────────────────────
+;; Client-side tool-call pruning or compaction broke affinity.
+
+(def SessionChurnDetectedEvent
+  [:merge BaseEvent
+   [:map
+    [:event-type            [:= :session-churn-detected]]
+    [:session-id            SessionId]
+    [:churn-type            ChurnType]
+    [:prefix-similarity-before {:optional true} :double]   ;; 0..1
+    [:prefix-similarity-after  {:optional true} :double]
+    [:message-count-before  {:optional true} :int]
+    [:message-count-after   {:optional true} :int]]])
+
+;; ── 6. Context overflow detected ────────────────────────────────────────────
+;; Hit practical context limit for (provider, model).
+;; Distinct from advertised limit — captures actual observed behavior.
+
+(def ContextOverflowDetectedEvent
+  [:merge BaseEvent
+   [:map
+    [:event-type               [:= :context-overflow-detected]]
+    [:session-id               SessionId]
+    [:tokens-in                :int]
+    [:tokens-out               {:optional true} :int]
+    [:advertised-context-limit {:optional true} :int]
+    [:observed-limit-estimate  {:optional true} :int]
+    [:overflow-signal          [:enum :hard-error :soft-truncation :empty-response :provider-message]]
+    [:raw-signal               {:optional true} :string]]])
+
+;; ── 7. Account cooldown initiated ───────────────────────────────────────────
+
+(def AccountCooldownInitiatedEvent
+  [:merge BaseEvent
+   [:map
+    [:event-type       [:= :account-cooldown-initiated]]
+    [:reason           CooldownReason]
+    [:cooldown-until   :int]       ;; epoch ms — expected expiry
+    [:triggering-event-id {:optional true} :string]]])
+
+;; ── 8. Account cooldown expired ─────────────────────────────────────────────
+
+(def AccountCooldownExpiredEvent
+  [:merge BaseEvent
+   [:map
+    [:event-type        [:= :account-cooldown-expired]]
+    [:cooldown-initiated-at :int]
+    [:cooldown-reason   CooldownReason]]])
+
+;; ── 9. Quota reset detected ─────────────────────────────────────────────────
+
+(def QuotaResetDetectedEvent
+  [:merge BaseEvent
+   [:map
+    [:event-type      [:= :quota-reset-detected]]
+    [:window-type     QuotaWindowType]
+    [:detected-via    [:enum :explicit-api :inferred-from-traffic :manual]]
+    [:tokens-available {:optional true} :int]
+    [:reset-at        {:optional true} :int]]])
+
+;; ── 10. Account health degraded ─────────────────────────────────────────────
+
+(def AccountHealthDegradedEvent
+  [:merge BaseEvent
+   [:map
+    [:event-type          [:= :account-health-degraded]]
+    [:health-score-before :double]
+    [:health-score-after  :double]
+    [:degraded-threshold  :double]
+    [:contributing-metrics {:optional true}
+     [:map
+      [:error-rate    {:optional true} :double]
+      [:p50-latency-ms {:optional true} :double]
+      [:p99-latency-ms {:optional true} :double]
+      [:quota-pressure {:optional true} :double]]]]])
+
+;; ── 11. Account health improved ─────────────────────────────────────────────
+
+(def AccountHealthImprovedEvent
+  [:merge BaseEvent
+   [:map
+    [:event-type           [:= :account-health-improved]]
+    [:health-score-before  :double]
+    [:health-score-after   :double]
+    [:recovery-threshold   :double]
+    [:contributing-metrics {:optional true}
+     [:map
+      [:error-rate    {:optional true} :double]
+      [:p50-latency-ms {:optional true} :double]
+      [:p99-latency-ms {:optional true} :double]
+      [:quota-pressure {:optional true} :double]]]]])
+
+;; ── Union / dispatch ─────────────────────────────────────────────────────────
+;; All ledger events as a tagged union, dispatch on :event-type.
+
+(def LedgerEvent
+  [:multi {:dispatch :event-type}
+   [:session-start                SessionStartEvent]
+   [:empty-provider-response      EmptyProviderResponseEvent]
+   [:unrecognized-response-schema UnrecognizedSchemaEvent]
+   [:session-account-changed      SessionAccountChangedEvent]
+   [:session-model-changed        SessionModelChangedEvent]
+   [:session-churn-detected       SessionChurnDetectedEvent]
+   [:context-overflow-detected    ContextOverflowDetectedEvent]
+   [:account-cooldown-initiated   AccountCooldownInitiatedEvent]
+   [:account-cooldown-expired     AccountCooldownExpiredEvent]
+   [:quota-reset-detected         QuotaResetDetectedEvent]
+   [:account-health-degraded      AccountHealthDegradedEvent]
+   [:account-health-improved      AccountHealthImprovedEvent]])
+
+(def registry
+  {:ledger/event                    LedgerEvent
+   :ledger/session-start            SessionStartEvent
+   :ledger/empty-provider-response  EmptyProviderResponseEvent
+   :ledger/unrecognized-schema      UnrecognizedSchemaEvent
+   :ledger/session-account-changed  SessionAccountChangedEvent
+   :ledger/session-model-changed    SessionModelChangedEvent
+   :ledger/session-churn            SessionChurnDetectedEvent
+   :ledger/context-overflow         ContextOverflowDetectedEvent
+   :ledger/cooldown-initiated       AccountCooldownInitiatedEvent
+   :ledger/cooldown-expired         AccountCooldownExpiredEvent
+   :ledger/quota-reset              QuotaResetDetectedEvent
+   :ledger/health-degraded          AccountHealthDegradedEvent
+   :ledger/health-improved          AccountHealthImprovedEvent})

--- a/src/proxx/ledger/schema.cljs
+++ b/src/proxx/ledger/schema.cljs
@@ -29,9 +29,7 @@
 (def ChurnType        [:enum :tool-call-pruning :compaction :client-unknown])
 (def CooldownReason   [:enum :quota-short :quota-weekly :error-rate :latency :manual])
 
-;; ── Base event fields (inlined into every event schema) ──────────────────────
-;; :merge is not available in CLJS malli without a custom registry.
-;; We inline the common fields directly into each event map instead.
+;; ── Base event fields ────────────────────────────────────────────────────────
 
 (def ^:private base-fields
   [[:event-id    :string]
@@ -43,10 +41,21 @@
    [:model-id    {:optional true} s/ModelId]
    [:provenance  {:optional true} s/Provenance]])
 
+(defn- field-key
+  "Extracts the keyword key from a malli map field entry."
+  [field]
+  (if (map? (second field))
+    (first field)   ; [:key {:optional true} schema]
+    (first field))) ; [:key schema]
+
 (defn- event-map
-  "Builds a [:map ...] schema from base-fields plus extra-fields."
+  "Builds a [:map ...] schema merging base-fields with extra-fields.
+   extra-fields win on duplicate keys — base entries are dropped for any
+   key that appears in extra-fields."
   [extra-fields]
-  (into [:map] (concat base-fields extra-fields)))
+  (let [override-keys (set (map field-key extra-fields))
+        filtered-base (remove #(override-keys (field-key %)) base-fields)]
+    (into [:map] (concat filtered-base extra-fields))))
 
 ;; ── 1. Session start ─────────────────────────────────────────────────────────
 
@@ -145,7 +154,7 @@
 
 (def AccountCooldownExpiredEvent
   (event-map
-   [[:event-type           [:= :account-cooldown-expired]]
+   [[:event-type            [:= :account-cooldown-expired]]
     [:cooldown-initiated-at :int]
     [:cooldown-reason       CooldownReason]]))
 
@@ -221,5 +230,4 @@
    :ledger/health-degraded          AccountHealthDegradedEvent
    :ledger/health-improved          AccountHealthImprovedEvent})
 
-;; Validate registry compiles cleanly at load time.
 (def _check (m/schema [:map-of :keyword :any]))

--- a/src/proxx/pipeline.cljs
+++ b/src/proxx/pipeline.cljs
@@ -1,0 +1,50 @@
+(ns proxx.pipeline
+  (:require [proxx.cache-policy :as cp]
+            [proxx.store.protocol :as store]))
+
+(defn make-pipeline
+  [{:keys [hot redis lmdb postgres]}]
+  {:stores {:hot      hot
+            :redis    redis
+            :lmdb     lmdb
+            :postgres postgres}})
+
+(defn store-for [pipeline store-key]
+  (get-in pipeline [:stores store-key]))
+
+(defn route!
+  "Write a record through the write-through chain defined by cache policy.
+   Assumes record already validated and provenance-stamped."
+  [pipeline entity-type record]
+  (let [policy      (get cp/policies entity-type)
+        write-chain (:write-through policy [:postgres])
+        k           (or (:id record)
+                        (:prompt-cache-key record)
+                        (:provider-id record))]
+    ;; always write hot cache first
+    (store/store-put (store-for pipeline :hot) entity-type k record)
+    ;; then follow declared chain
+    (doseq [store-key write-chain]
+      (when-let [s (store-for pipeline store-key)]
+        (store/store-put s entity-type k record)))
+    record))
+
+(defn fetch!
+  "Read a record through the read-order chain.
+   On cache miss, back-fill upstream layers."
+  [pipeline entity-type k]
+  (let [policy     (get cp/policies entity-type)
+        read-chain (:read-order policy [:postgres])
+        full-chain (cons :hot read-chain)]
+    (loop [remaining full-chain]
+      (when-let [store-key (first remaining)]
+        (let [s (store-for pipeline store-key)
+              v (when s (store/store-get s entity-type k))]
+          (if v
+            (do
+              ;; backfill earlier caches
+              (doseq [backfill-key (take-while #(not= % store-key) full-chain)]
+                (when-let [bs (store-for pipeline backfill-key)]
+                  (store/store-put bs entity-type k v)))
+              v)
+            (recur (rest remaining)))))))

--- a/src/proxx/pipeline.cljs
+++ b/src/proxx/pipeline.cljs
@@ -21,9 +21,7 @@
         k           (or (:id record)
                         (:prompt-cache-key record)
                         (:provider-id record))]
-    ;; always write hot cache first
     (store/store-put (store-for pipeline :hot) entity-type k record)
-    ;; then follow declared chain
     (doseq [store-key write-chain]
       (when-let [s (store-for pipeline store-key)]
         (store/store-put s entity-type k record)))
@@ -42,9 +40,8 @@
               v (when s (store/store-get s entity-type k))]
           (if v
             (do
-              ;; backfill earlier caches
               (doseq [backfill-key (take-while #(not= % store-key) full-chain)]
                 (when-let [bs (store-for pipeline backfill-key)]
                   (store/store-put bs entity-type k v)))
               v)
-            (recur (rest remaining)))))))
+            (recur (rest remaining))))))))

--- a/src/proxx/processor.cljs
+++ b/src/proxx/processor.cljs
@@ -21,7 +21,7 @@
   [record source & [{:keys [seed-hash request-id]}]]
   (assoc record :provenance
          (cond-> {:source      source
-                  :ingested-at (System/currentTimeMillis)}
+                  :ingested-at (.getTime (js/Date.))}
            seed-hash  (assoc :seed-hash seed-hash)
            request-id (assoc :request-id request-id))))
 
@@ -33,16 +33,14 @@
       [:ok record]
       [:error (m/explain schema record)])))
 
-;; Prompt affinity state transition
-
 (defn apply-affinity-event
   "Pure state transition for prompt affinity.
    state  - existing PromptAffinityRecord map or nil
    event  - {:type :note-success|:upsert|:delete, :prompt-cache-key .. :provider-id .. :account-id ..}
    opts   - {:promotion-threshold int}"
-  [state {:keys [type prompt-cache-key provider-id account-id] :as event} {:keys [promotion-threshold]}]
-  (let [now (System/currentTimeMillis)]
-    (case type
+  [state {:keys [event-type prompt-cache-key provider-id account-id]} {:keys [promotion-threshold]}]
+  (let [now (.getTime (js/Date.))]
+    (case event-type
       :delete nil
       :upsert {:prompt-cache-key (or (:prompt-cache-key state) prompt-cache-key)
                :provider-id      provider-id
@@ -79,22 +77,17 @@
                    :provisional-success-count new-count
                    :updated-at                now)))))))
 
-;; Pheromone projection
-
 (defn project-pheromone
-  "Compute current pheromone score from a seq of {:ts epoch-ms :outcome :success|:failure|...}.
-   decay-half-life-ms is the time for the contribution to halve."
+  "Compute current pheromone score from a seq of {:ts epoch-ms :outcome :success|:failure|...}."
   [events {:keys [decay-half-life-ms] :or {decay-half-life-ms 60000}}]
-  (let [now (System/currentTimeMillis)]
+  (let [now (.getTime (js/Date.))]
     (reduce (fn [acc {:keys [ts outcome]}]
               (let [age          (- now ts)
-                    decay-factor (Math/pow 0.5 (/ age decay-half-life-ms))
+                    decay-factor (js/Math.pow 0.5 (/ age decay-half-life-ms))
                     signal       (if (= outcome :success) 1.0 -0.5)]
                 (+ acc (* signal decay-factor))))
             0.0
             events)))
-
-;; Scoring helpers
 
 (defn apply-weight-transform [value transform]
   (case transform
@@ -108,8 +101,7 @@
     (fn [score {:keys [metric-key weight transform]}]
       (let [path  (mapv keyword (str/split metric-key #"\."))
             value (get-in metrics path 0.0)]
-        (+ score (* weight (apply-weight-transform value transform))))
-      )
+        (+ score (* weight (apply-weight-transform value transform)))))
     0.0
     weights))
 

--- a/src/proxx/processor.cljs
+++ b/src/proxx/processor.cljs
@@ -1,0 +1,124 @@
+(ns proxx.processor
+  (:require [clojure.string :as str]
+            [malli.core :as m]
+            [proxx.schema :as s]))
+
+(defn normalize-keys
+  "Recursively converts string / camelCase / snake_case keys to kebab-case keywords."
+  [m]
+  (reduce-kv
+    (fn [acc k v]
+      (let [kw (-> (name k)
+                   (str/replace #"([A-Z])" "-$1")
+                   (str/replace #"_" "-")
+                   (str/lower-case)
+                   keyword)]
+        (assoc acc kw (if (map? v) (normalize-keys v) v))))
+    {}
+    m))
+
+(defn stamp-provenance
+  [record source & [{:keys [seed-hash request-id]}]]
+  (assoc record :provenance
+         (cond-> {:source      source
+                  :ingested-at (System/currentTimeMillis)}
+           seed-hash  (assoc :seed-hash seed-hash)
+           request-id (assoc :request-id request-id))))
+
+(defn validate
+  "Returns [:ok record] or [:error explain-data]."
+  [schema-key record]
+  (let [schema (get s/registry schema-key)]
+    (if (m/validate schema record)
+      [:ok record]
+      [:error (m/explain schema record)])))
+
+;; Prompt affinity state transition
+
+(defn apply-affinity-event
+  "Pure state transition for prompt affinity.
+   state  - existing PromptAffinityRecord map or nil
+   event  - {:type :note-success|:upsert|:delete, :prompt-cache-key .. :provider-id .. :account-id ..}
+   opts   - {:promotion-threshold int}"
+  [state {:keys [type prompt-cache-key provider-id account-id] :as event} {:keys [promotion-threshold]}]
+  (let [now (System/currentTimeMillis)]
+    (case type
+      :delete nil
+      :upsert {:prompt-cache-key (or (:prompt-cache-key state) prompt-cache-key)
+               :provider-id      provider-id
+               :account-id       account-id
+               :updated-at       now}
+      :note-success
+      (cond
+        (nil? state)
+        {:prompt-cache-key prompt-cache-key
+         :provider-id      provider-id
+         :account-id       account-id
+         :updated-at       now}
+
+        (and (= (:provider-id state) provider-id)
+             (= (:account-id state) account-id))
+        (-> state
+            (dissoc :provisional-provider-id :provisional-account-id :provisional-success-count)
+            (assoc :updated-at now))
+
+        :else
+        (let [same-prov? (and (= (:provisional-provider-id state) provider-id)
+                              (= (:provisional-account-id state) account-id))
+              new-count  (if same-prov?
+                           (inc (or (:provisional-success-count state) 1))
+                           1)]
+          (if (>= new-count promotion-threshold)
+            {:prompt-cache-key (:prompt-cache-key state)
+             :provider-id      provider-id
+             :account-id       account-id
+             :updated-at       now}
+            (assoc state
+                   :provisional-provider-id   provider-id
+                   :provisional-account-id    account-id
+                   :provisional-success-count new-count
+                   :updated-at                now)))))))
+
+;; Pheromone projection
+
+(defn project-pheromone
+  "Compute current pheromone score from a seq of {:ts epoch-ms :outcome :success|:failure|...}.
+   decay-half-life-ms is the time for the contribution to halve."
+  [events {:keys [decay-half-life-ms] :or {decay-half-life-ms 60000}}]
+  (let [now (System/currentTimeMillis)]
+    (reduce (fn [acc {:keys [ts outcome]}]
+              (let [age          (- now ts)
+                    decay-factor (Math/pow 0.5 (/ age decay-half-life-ms))
+                    signal       (if (= outcome :success) 1.0 -0.5)]
+                (+ acc (* signal decay-factor))))
+            0.0
+            events)))
+
+;; Scoring helpers
+
+(defn apply-weight-transform [value transform]
+  (case transform
+    :linear    value
+    :invert    (- 1.0 value)
+    :normalize value
+    value))
+
+(defn compute-score [metrics weights]
+  (reduce
+    (fn [score {:keys [metric-key weight transform]}]
+      (let [path  (mapv keyword (str/split metric-key #"\."))
+            value (get-in metrics path 0.0)]
+        (+ score (* weight (apply-weight-transform value transform))))
+      )
+    0.0
+    weights))
+
+(defn score-candidates
+  "Attach :score to each candidate given a metrics-map and scoring weights.
+   metrics-map keyed by [provider-id model-id] -> metric map."
+  [candidates metrics-map weights]
+  (mapv (fn [c]
+          (let [k       [(:provider-id c) (:model-id c)]
+                metrics (get metrics-map k {})]
+            (assoc c :score (compute-score metrics weights))))
+        candidates))

--- a/src/proxx/schema.cljs
+++ b/src/proxx/schema.cljs
@@ -1,9 +1,5 @@
 (ns proxx.schema
-  (:require [malli.core :as m]
-            [malli.registry :as mr]
-            [clojure.string :as str]))
-
-;; Primitive aliases
+  (:require [malli.core :as m]))
 
 (def ProviderId :string)
 (def AccountId  :string)
@@ -11,16 +7,12 @@
 (def TenantId   :string)
 (def PromptHash :string)
 
-;; Provenance metadata attached to all ingested records
-
 (def Provenance
   [:map
    [:source      [:enum :seed :rest :ws :redis :lmdb :postgres]]
    [:ingested-at :int]
    [:seed-hash   {:optional true} :string]
    [:request-id  {:optional true} :string]])
-
-;; Core domain schemas
 
 (def Provider
   [:map
@@ -96,3 +88,7 @@
    :routing-policy    RoutingPolicy
    :affinity-policy   AffinityPolicy
    :provenance        Provenance})
+
+;; Trigger malli registry compilation to catch schema errors at load time.
+(def _validate-registry
+  (m/schema [:map-of :keyword :any]))

--- a/src/proxx/schema.cljs
+++ b/src/proxx/schema.cljs
@@ -1,0 +1,98 @@
+(ns proxx.schema
+  (:require [malli.core :as m]
+            [malli.registry :as mr]
+            [clojure.string :as str]))
+
+;; Primitive aliases
+
+(def ProviderId :string)
+(def AccountId  :string)
+(def ModelId    :string)
+(def TenantId   :string)
+(def PromptHash :string)
+
+;; Provenance metadata attached to all ingested records
+
+(def Provenance
+  [:map
+   [:source      [:enum :seed :rest :ws :redis :lmdb :postgres]]
+   [:ingested-at :int]
+   [:seed-hash   {:optional true} :string]
+   [:request-id  {:optional true} :string]])
+
+;; Core domain schemas
+
+(def Provider
+  [:map
+   [:id           ProviderId]
+   [:display-name :string]
+   [:enabled      :boolean]
+   [:meta         {:optional true} [:map-of :keyword :any]]])
+
+(def ProviderEndpoint
+  [:map
+   [:provider-id ProviderId]
+   [:endpoint    [:enum :completions :responses :anthropic :ollama]]
+   [:path        :string]
+   [:supported   :boolean]])
+
+(def ProviderModel
+  [:map
+   [:provider-id    ProviderId]
+   [:model-id       ModelId]
+   [:context-tokens :int]
+   [:streaming      :boolean]
+   [:vision         :boolean]
+   [:default-task   {:optional true} :string]
+   [:meta           {:optional true} [:map-of :keyword :any]]])
+
+(def PromptAffinityRecord
+  [:map
+   [:prompt-cache-key           PromptHash]
+   [:provider-id                ProviderId]
+   [:account-id                 AccountId]
+   [:provisional-provider-id    {:optional true} ProviderId]
+   [:provisional-account-id     {:optional true} AccountId]
+   [:provisional-success-count  {:optional true} :int]
+   [:updated-at                 :int]])
+
+(def PheromoneState
+  [:map
+   [:provider-id  ProviderId]
+   [:model-id     ModelId]
+   [:score        :double]
+   [:last-event-at :int]])
+
+(def ScoringWeight
+  [:map
+   [:profile-id :string]
+   [:metric-key :string]
+   [:weight     :double]
+   [:transform  [:enum :linear :invert :normalize]]])
+
+(def RoutingPolicy
+  [:map
+   [:id              :string]
+   [:scoring-profile :string]
+   [:sampler         [:enum :softmax :greedy :weighted-random :round-robin]]
+   [:sampler-params  {:optional true} [:map-of :keyword :any]]
+   [:max-attempts    :int]
+   [:fallback-policy {:optional true} :string]])
+
+(def AffinityPolicy
+  [:map
+   [:tenant-id                        {:optional true} TenantId]
+   [:provisional-promotion-threshold  :int]
+   [:affinity-ttl-seconds             {:optional true} :int]
+   [:enabled                          :boolean]])
+
+(def registry
+  {:provider          Provider
+   :provider-endpoint ProviderEndpoint
+   :provider-model    ProviderModel
+   :prompt-affinity   PromptAffinityRecord
+   :pheromone-state   PheromoneState
+   :scoring-weight    ScoringWeight
+   :routing-policy    RoutingPolicy
+   :affinity-policy   AffinityPolicy
+   :provenance        Provenance})

--- a/src/proxx/store/hot.cljs
+++ b/src/proxx/store/hot.cljs
@@ -1,0 +1,21 @@
+(ns proxx.store.hot
+  (:require [proxx.store.protocol :refer [IStore]]))
+
+(defrecord HotCache [state-atom]
+  IStore
+  (store-get [_ entity-type k]
+    (get-in @state-atom [entity-type k]))
+
+  (store-put [_ entity-type k v]
+    (swap! state-atom assoc-in [entity-type k] v)
+    nil)
+
+  (store-delete [_ entity-type k]
+    (swap! state-atom update entity-type dissoc k)
+    nil)
+
+  (store-list [_ entity-type]
+    (vals (get @state-atom entity-type)))
+
+  (store-close [_]
+    (reset! state-atom {})))

--- a/src/proxx/store/protocol.cljs
+++ b/src/proxx/store/protocol.cljs
@@ -1,0 +1,8 @@
+(ns proxx.store.protocol)
+
+(defprotocol IStore
+  (store-get    [this entity-type k])
+  (store-put    [this entity-type k record])
+  (store-delete [this entity-type k])
+  (store-list   [this entity-type])
+  (store-close  [this]))

--- a/test/proxx/ledger/projector_test.cljs
+++ b/test/proxx/ledger/projector_test.cljs
@@ -2,7 +2,7 @@
   (:require [cljs.test :refer-macros [deftest is testing]]
             [proxx.ledger.projector :as proj]))
 
-;; ── Helpers ───────────────────────────────────────────────────────────────────
+;; ── Helpers ──────────────────────────────────────────────────────────────────
 
 (def base-tuple
   {:session-id  "S1"
@@ -10,96 +10,120 @@
    :account-id  "A1"
    :model-id    "gpt-4o"})
 
-(defn ev [overrides]
+(defn mk-ev
+  "Minimal ledger event merged over base-tuple fields."
+  [overrides]
   (merge {:event-id   (str (random-uuid))
           :event-type :routing-attempt
-          :ts         (js/Date.now)
+          :ts         0
           :session-id  "S1"
           :provider-id "openai"
           :account-id  "A1"
           :model-id    "gpt-4o"}
          overrides))
 
-;; ── Epoch tests ───────────────────────────────────────────────────────────────
+;; ── Epoch ────────────────────────────────────────────────────────────────────
 
 (deftest epoch-0-when-no-failures
   (testing "epoch is sentinel when no failure events exist"
-    (let [ledger [(ev {:outcome :success :ts 1000})
-                  (ev {:outcome :success :ts 2000})]
+    (let [ledger [(mk-ev {:outcome :success :ts 1000})
+                  (mk-ev {:outcome :success :ts 2000})]
           epoch  (proj/current-epoch ledger base-tuple)]
       (is (= ::proj/epoch-0 epoch)))))
 
 (deftest epoch-derived-from-last-failure
-  (testing "epoch-id changes when a failure event is added"
-    (let [failure-ev (ev {:event-id   "fail-1"
+  (testing "epoch-id is a string derived from the failure event"
+    (let [fail-ev (mk-ev {:event-id   "fail-1"
                           :event-type :account-cooldown-initiated
-                          :outcome    :quota-exhausted
                           :ts         3000})
-          ledger     [(ev {:outcome :success :ts 1000})
-                      (ev {:outcome :success :ts 2000})
-                      failure-ev]
-          epoch      (proj/current-epoch ledger base-tuple)]
+          ledger  [(mk-ev {:outcome :success :ts 1000})
+                   (mk-ev {:outcome :success :ts 2000})
+                   fail-ev]
+          epoch   (proj/current-epoch ledger base-tuple)]
       (is (not= ::proj/epoch-0 epoch))
       (is (string? epoch)))))
 
 (deftest epoch-unchanged-with-same-ledger
-  (testing "epoch-unchanged? returns true when no new failures"
-    (let [failure-ev (ev {:event-id   "fail-1"
-                          :event-type :account-cooldown-initiated
-                          :ts         3000})
-          ledger     [(ev {:outcome :success :ts 1000})
-                      failure-ev]
-          epoch-id   (proj/current-epoch ledger base-tuple)]
+  (testing "epoch-unchanged? true when no new failures"
+    (let [fail-ev  (mk-ev {:event-id "fail-1" :event-type :account-cooldown-initiated :ts 3000})
+          ledger   [(mk-ev {:outcome :success :ts 1000}) fail-ev]
+          epoch-id (proj/current-epoch ledger base-tuple)]
       (is (proj/epoch-unchanged? epoch-id ledger base-tuple)))))
 
 (deftest epoch-changes-after-new-failure
-  (testing "epoch-unchanged? returns false after a second failure arrives"
-    (let [fail1   (ev {:event-id "fail-1" :event-type :account-cooldown-initiated :ts 2000})
-          ledger1 [(ev {:outcome :success :ts 1000}) fail1]
+  (testing "epoch-unchanged? false after a second failure"
+    (let [fail1   (mk-ev {:event-id "fail-1" :event-type :account-cooldown-initiated :ts 2000})
+          ledger1 [(mk-ev {:outcome :success :ts 1000}) fail1]
           epoch1  (proj/current-epoch ledger1 base-tuple)
-          fail2   (ev {:event-id "fail-2" :event-type :account-cooldown-initiated :ts 4000})
+          fail2   (mk-ev {:event-id "fail-2" :event-type :account-cooldown-initiated :ts 4000})
           ledger2 (conj ledger1 fail2)]
       (is (not (proj/epoch-unchanged? epoch1 ledger2 base-tuple))))))
 
-;; ── Cache recoverability ──────────────────────────────────────────────────────
+;; ── Cache recoverability ─────────────────────────────────────────────────────
+;;
+;; OpenAI provider-cache-config:
+;;   :cache-ttl-ms          24h = 86_400_000 ms
+;;   :short-quota-window-ms  5h = 18_000_000 ms
+;;
+;; For cache-recoverable? to return true:
+;;   (< (- now success-ts) 86_400_000)   → now must be within 24h of last success
+;;   (>= (- now failure-ts) 18_000_000)  → now must be ≥5h after last failure
 
 (deftest cache-not-recoverable-without-success
-  (testing "cache-recoverable? is false when no success events exist"
-    (let [ledger [(ev {:event-type :account-cooldown-initiated :ts 1000})]
+  (testing "cache-recoverable? false when no success events"
+    (let [ledger [(mk-ev {:event-type :account-cooldown-initiated :ts 1000})]
           now    (+ 1000 (* 6 60 60 1000))]
       (is (not (proj/cache-recoverable? ledger base-tuple "openai" now))))))
 
 (deftest cache-recoverable-within-ttl-after-short-reset
-  (testing "cache-recoverable? is true when within 24h and 5h short window elapsed"
-    (let [t0       0
-          t-fail   (* 5 60 60 1000)      ;; fail at 5h
-          t-now    (* 6 60 60 1000)      ;; check at 6h (5h after failure, inside 24h TTL)
-          ledger   [(ev {:outcome :success :ts t0})
-                    (ev {:event-type :account-cooldown-initiated :ts t-fail})]]
+  (testing "cache-recoverable? true: within 24h of success, ≥5h after failure"
+    (let [t-success 0
+          t-fail    (* 1 60 60 1000)    ;; fail at  1h
+          t-now     (* 6 60 60 1000)    ;; check at 6h → 5h after failure ✓, 6h after success (< 24h) ✓
+          ledger    [(mk-ev {:outcome :success :ts t-success})
+                     (mk-ev {:event-type :account-cooldown-initiated :ts t-fail})]]
       (is (proj/cache-recoverable? ledger base-tuple "openai" t-now)))))
 
-(deftest cache-not-recoverable-after-churn
-  (testing "cache-recoverable? is false if churn happened after last success"
-    (let [t0      0
-          t-churn 1000
-          t-fail  (* 5 60 60 1000)
-          t-now   (* 6 60 60 1000)
-          ledger  [(ev {:outcome :success :ts t0})
-                   (ev {:event-type :session-churn-detected :ts t-churn})
-                   (ev {:event-type :account-cooldown-initiated :ts t-fail})]]
+(deftest cache-expired-beyond-ttl
+  (testing "cache-recoverable? false when beyond 24h TTL since last success"
+    (let [t-success 0
+          t-fail    (* 1  60 60 1000)   ;; fail at  1h
+          t-now     (* 25 60 60 1000)   ;; check at 25h → beyond 24h TTL
+          ledger    [(mk-ev {:outcome :success :ts t-success})
+                     (mk-ev {:event-type :account-cooldown-initiated :ts t-fail})]]
       (is (not (proj/cache-recoverable? ledger base-tuple "openai" t-now))))))
 
-;; ── Prefix similarity ─────────────────────────────────────────────────────────
+(deftest cache-not-recoverable-short-window-not-elapsed
+  (testing "cache-recoverable? false when < 5h since failure"
+    (let [t-success 0
+          t-fail    (* 1 60 60 1000)    ;; fail at 1h
+          t-now     (* 2 60 60 1000)    ;; check at 2h → only 1h after failure, need 5h
+          ledger    [(mk-ev {:outcome :success :ts t-success})
+                     (mk-ev {:event-type :account-cooldown-initiated :ts t-fail})]]
+      (is (not (proj/cache-recoverable? ledger base-tuple "openai" t-now))))))
+
+(deftest cache-not-recoverable-after-churn
+  (testing "cache-recoverable? false if churn occurred after last success"
+    (let [t-success 0
+          t-churn   (* 1 60 60 1000)
+          t-fail    (* 2 60 60 1000)
+          t-now     (* 8 60 60 1000)   ;; 6h after failure, within 24h TTL — would pass without churn
+          ledger    [(mk-ev {:outcome :success      :ts t-success})
+                     (mk-ev {:event-type :session-churn-detected       :ts t-churn})
+                     (mk-ev {:event-type :account-cooldown-initiated    :ts t-fail})]]
+      (is (not (proj/cache-recoverable? ledger base-tuple "openai" t-now))))))
+
+;; ── Prefix similarity ────────────────────────────────────────────────────────
 
 (deftest prefix-similarity-identical
-  (testing "prefix-similarity is 1.0 when counts are equal"
+  (testing "1.0 when counts are equal"
     (is (= 1.0 (proj/prefix-similarity 10 10)))))
 
 (deftest prefix-similarity-half
-  (testing "prefix-similarity is 0.5 when current is half original"
+  (testing "0.5 when current is half original"
     (is (= 0.5 (proj/prefix-similarity 10 5)))))
 
 (deftest prefix-similarity-zero-guard
-  (testing "prefix-similarity returns 0.0 when original count is zero or nil"
+  (testing "0.0 when original count is zero or nil"
     (is (= 0.0 (proj/prefix-similarity 0 10)))
     (is (= 0.0 (proj/prefix-similarity nil 10)))))

--- a/test/proxx/ledger/projector_test.cljs
+++ b/test/proxx/ledger/projector_test.cljs
@@ -1,0 +1,105 @@
+(ns proxx.ledger.projector-test
+  (:require [cljs.test :refer-macros [deftest is testing]]
+            [proxx.ledger.projector :as proj]))
+
+;; ── Helpers ───────────────────────────────────────────────────────────────────
+
+(def base-tuple
+  {:session-id  "S1"
+   :provider-id "openai"
+   :account-id  "A1"
+   :model-id    "gpt-4o"})
+
+(defn ev [overrides]
+  (merge {:event-id   (str (random-uuid))
+          :event-type :routing-attempt
+          :ts         (js/Date.now)
+          :session-id  "S1"
+          :provider-id "openai"
+          :account-id  "A1"
+          :model-id    "gpt-4o"}
+         overrides))
+
+;; ── Epoch tests ───────────────────────────────────────────────────────────────
+
+(deftest epoch-0-when-no-failures
+  (testing "epoch is sentinel when no failure events exist"
+    (let [ledger [(ev {:outcome :success :ts 1000})
+                  (ev {:outcome :success :ts 2000})]
+          epoch  (proj/current-epoch ledger base-tuple)]
+      (is (= ::proj/epoch-0 epoch)))))
+
+(deftest epoch-derived-from-last-failure
+  (testing "epoch-id changes when a failure event is added"
+    (let [failure-ev (ev {:event-id   "fail-1"
+                          :event-type :account-cooldown-initiated
+                          :outcome    :quota-exhausted
+                          :ts         3000})
+          ledger     [(ev {:outcome :success :ts 1000})
+                      (ev {:outcome :success :ts 2000})
+                      failure-ev]
+          epoch      (proj/current-epoch ledger base-tuple)]
+      (is (not= ::proj/epoch-0 epoch))
+      (is (string? epoch)))))
+
+(deftest epoch-unchanged-with-same-ledger
+  (testing "epoch-unchanged? returns true when no new failures"
+    (let [failure-ev (ev {:event-id   "fail-1"
+                          :event-type :account-cooldown-initiated
+                          :ts         3000})
+          ledger     [(ev {:outcome :success :ts 1000})
+                      failure-ev]
+          epoch-id   (proj/current-epoch ledger base-tuple)]
+      (is (proj/epoch-unchanged? epoch-id ledger base-tuple)))))
+
+(deftest epoch-changes-after-new-failure
+  (testing "epoch-unchanged? returns false after a second failure arrives"
+    (let [fail1   (ev {:event-id "fail-1" :event-type :account-cooldown-initiated :ts 2000})
+          ledger1 [(ev {:outcome :success :ts 1000}) fail1]
+          epoch1  (proj/current-epoch ledger1 base-tuple)
+          fail2   (ev {:event-id "fail-2" :event-type :account-cooldown-initiated :ts 4000})
+          ledger2 (conj ledger1 fail2)]
+      (is (not (proj/epoch-unchanged? epoch1 ledger2 base-tuple))))))
+
+;; ── Cache recoverability ──────────────────────────────────────────────────────
+
+(deftest cache-not-recoverable-without-success
+  (testing "cache-recoverable? is false when no success events exist"
+    (let [ledger [(ev {:event-type :account-cooldown-initiated :ts 1000})]
+          now    (+ 1000 (* 6 60 60 1000))]
+      (is (not (proj/cache-recoverable? ledger base-tuple "openai" now))))))
+
+(deftest cache-recoverable-within-ttl-after-short-reset
+  (testing "cache-recoverable? is true when within 24h and 5h short window elapsed"
+    (let [t0       0
+          t-fail   (* 5 60 60 1000)      ;; fail at 5h
+          t-now    (* 6 60 60 1000)      ;; check at 6h (5h after failure, inside 24h TTL)
+          ledger   [(ev {:outcome :success :ts t0})
+                    (ev {:event-type :account-cooldown-initiated :ts t-fail})]]
+      (is (proj/cache-recoverable? ledger base-tuple "openai" t-now)))))
+
+(deftest cache-not-recoverable-after-churn
+  (testing "cache-recoverable? is false if churn happened after last success"
+    (let [t0      0
+          t-churn 1000
+          t-fail  (* 5 60 60 1000)
+          t-now   (* 6 60 60 1000)
+          ledger  [(ev {:outcome :success :ts t0})
+                   (ev {:event-type :session-churn-detected :ts t-churn})
+                   (ev {:event-type :account-cooldown-initiated :ts t-fail})]]
+      (is (not (proj/cache-recoverable? ledger base-tuple "openai" t-now))))))
+
+;; ── Prefix similarity ─────────────────────────────────────────────────────────
+
+(deftest prefix-similarity-identical
+  (testing "prefix-similarity is 1.0 when counts are equal"
+    (is (= 1.0 (proj/prefix-similarity 10 10)))))
+
+(deftest prefix-similarity-half
+  (testing "prefix-similarity is 0.5 when current is half original"
+    (is (= 0.5 (proj/prefix-similarity 10 5)))))
+
+(deftest prefix-similarity-zero-guard
+  (testing "prefix-similarity returns 0.0 when original count is zero or nil"
+    (is (= 0.0 (proj/prefix-similarity 0 10)))
+    (is (= 0.0 (proj/prefix-similarity nil 10)))))

--- a/test/proxx/ledger/schema_test.cljs
+++ b/test/proxx/ledger/schema_test.cljs
@@ -73,4 +73,4 @@
                       :derived-cache-key "dck-xyz"
                       :provider-id       "openai"
                       :account-id        "A1"
-                      :model-id          "gpt-4o"}))))))
+                      :model-id          "gpt-4o"})))))

--- a/test/proxx/ledger/schema_test.cljs
+++ b/test/proxx/ledger/schema_test.cljs
@@ -1,0 +1,76 @@
+(ns proxx.ledger.schema-test
+  (:require [cljs.test :refer-macros [deftest is testing]]
+            [malli.core :as m]
+            [proxx.ledger.schema :as ls]))
+
+(defn valid? [schema-key val]
+  (m/validate (get ls/registry schema-key) val))
+
+(deftest session-start-valid
+  (testing "well-formed session_start passes validation"
+    (is (valid? :ledger/session-start
+                {:event-id         "ev-1"
+                 :event-type       :session-start
+                 :ts               1000
+                 :session-id       "S1"
+                 :harness-id       "opencode"
+                 :harness-cache-key "hck-abc"
+                 :derived-cache-key "dck-xyz"
+                 :provider-id      "openai"
+                 :account-id       "A1"
+                 :model-id         "gpt-4o"}))))
+
+(deftest empty-provider-response-valid
+  (testing "well-formed empty_provider_response passes validation"
+    (is (valid? :ledger/empty-provider-response
+                {:event-id   "ev-2"
+                 :event-type :empty-provider-response
+                 :ts         2000
+                 :session-id  "S1"
+                 :provider-id "ollama-cloud"
+                 :account-id  "A2"
+                 :model-id    "qwen-coder"
+                 :request-id  "req-1"
+                 :http-status 200
+                 :raw-body    "{\"error\":\"rate limit exceeded\"}"
+                 :outcome     :quota-exhausted-in-body}))))
+
+(deftest cooldown-initiated-valid
+  (testing "well-formed account_cooldown_initiated passes validation"
+    (is (valid? :ledger/cooldown-initiated
+                {:event-id       "ev-3"
+                 :event-type     :account-cooldown-initiated
+                 :ts             3000
+                 :provider-id    "openai"
+                 :account-id     "A1"
+                 :model-id       "gpt-4o"
+                 :reason         :quota-short
+                 :cooldown-until 99999000}))))
+
+(deftest health-degraded-valid
+  (testing "well-formed account_health_degraded passes validation"
+    (is (valid? :ledger/health-degraded
+                {:event-id             "ev-4"
+                 :event-type           :account-health-degraded
+                 :ts                   4000
+                 :provider-id          "anthropic"
+                 :account-id           "A3"
+                 :model-id             "claude-3-5-sonnet"
+                 :health-score-before  0.9
+                 :health-score-after   0.4
+                 :degraded-threshold   0.5
+                 :contributing-metrics {:error-rate 0.3
+                                        :p50-latency-ms 900.0}}))))
+
+(deftest missing-required-field-fails
+  (testing "missing event-id fails validation"
+    (is (not (valid? :ledger/session-start
+                     {:event-type       :session-start
+                      :ts               1000
+                      :session-id       "S1"
+                      :harness-id       "opencode"
+                      :harness-cache-key "hck-abc"
+                      :derived-cache-key "dck-xyz"
+                      :provider-id      "openai"
+                      :account-id       "A1"
+                      :model-id         "gpt-4o"})))))  

--- a/test/proxx/ledger/schema_test.cljs
+++ b/test/proxx/ledger/schema_test.cljs
@@ -3,8 +3,8 @@
             [malli.core :as m]
             [proxx.ledger.schema :as ls]))
 
-(defn valid? [schema-key val]
-  (m/validate (get ls/registry schema-key) val))
+(defn valid? [schema-key value]
+  (m/validate (get ls/registry schema-key) value))
 
 (deftest session-start-valid
   (testing "well-formed session_start passes validation"
@@ -65,12 +65,12 @@
 (deftest missing-required-field-fails
   (testing "missing event-id fails validation"
     (is (not (valid? :ledger/session-start
-                     {:event-type       :session-start
-                      :ts               1000
-                      :session-id       "S1"
-                      :harness-id       "opencode"
+                     {:event-type        :session-start
+                      :ts                1000
+                      :session-id        "S1"
+                      :harness-id        "opencode"
                       :harness-cache-key "hck-abc"
                       :derived-cache-key "dck-xyz"
-                      :provider-id      "openai"
-                      :account-id       "A1"
-                      :model-id         "gpt-4o"})))))  
+                      :provider-id       "openai"
+                      :account-id        "A1"
+                      :model-id          "gpt-4o"}))))))


### PR DESCRIPTION
## Summary

This PR introduces a first-pass, data-oriented routing spec and implementation skeleton in ClojureScript (shadow-cljs compatible) for Proxx.

The goal is to clearly separate **schemas**, **pure data processors**, **cache policy**, and **store drivers**, setting up a DoT-style chain-of-custody pipeline for routing, affinity, pheromones, and policies.

## What’s included

### 1. Schemas (malli)

New namespace: `proxx.schema`

Defines core domain schemas and a registry:
- `Provider`, `ProviderEndpoint`, `ProviderModel`
- `PromptAffinityRecord`, `PheromoneState`
- `ScoringWeight`, `RoutingPolicy`, `AffinityPolicy`
- `Provenance` metadata attached to all ingested records

This gives us a single source of truth for structure and validation when data enters the system (via seed, REST, WS, or DB).

### 2. Pure data processors

New namespace: `proxx.processor`

- `normalize-keys` – converts external JSON/SQL key styles (camelCase, snake_case, strings) to canonical kebab-case keywords.
- `stamp-provenance` – attaches `:provenance` metadata with `:source`, `:ingested-at`, and optional `:seed-hash` / `:request-id`.
- `validate` – wraps malli validation over entries in `proxx.schema/registry` and returns `[:ok record]` or `[:error explain]`.
- `apply-affinity-event` – pure prompt affinity state transition for the `note-success` / `upsert` / `delete` state machine (mirroring the SQL prompt affinity store, but factored into a pure function).
- `project-pheromone` – pure pheromone score projection using an exponential decay over recent events.
- `compute-score` / `score-candidates` – generic scoring helpers that combine metrics with configured `ScoringWeight`s.

These functions are IO-free and unit-testable in isolation.

### 3. Cache policy as data

New namespace: `proxx.cache-policy`

Defines a data map of cache policy per entity type:
- TTLs for Redis and LMDB
- `:write-through` chain (e.g., `[:redis :lmdb :postgres]`)
- `:read-order` chain (e.g., `[:redis :lmdb :postgres]`)

Entities covered: `:provider`, `:provider-model`, `:prompt-affinity`, `:pheromone-state`, `:routing-policy`, `:affinity-policy`.

Policy lives in one place and is consumed by the pipeline; drivers remain policy-blind.

### 4. Store protocol and hot cache driver

New namespaces:
- `proxx.store.protocol`
- `proxx.store.hot`

`IStore` protocol defines a minimal interface for stores:
- `store-get`, `store-put`, `store-delete`, `store-list`, `store-close`

`HotCache` is an in-process atom-backed store for truly hot data within a process/request lifetime, implementing `IStore`.

This sets a consistent contract for Redis, LMDB, Postgres, and seed drivers that will follow.

### 5. Pipeline skeleton

New namespace: `proxx.pipeline`

Defines the chain-of-custody orchestrator:

- `make-pipeline` – wires named stores (`:hot`, `:redis`, `:lmdb`, `:postgres`) into a pipeline map.
- `store-for` – helper to look up a store by key.
- `route!` – write-through function that:
  - chooses a key (prefers `:id`, then `:prompt-cache-key`, then `:provider-id`)
  - writes to the hot cache
  - writes to each store in the configured `:write-through` chain for the entity type.
- `fetch!` – read-through function that:
  - attempts to read from `:hot` then each store in the configured `:read-order` chain
  - back-fills upstream caches when it finds a record.

This pipeline is the single place where cache policy is interpreted; store drivers themselves just obey `IStore`.

## Intent and next steps

This is intentionally a **first-pass skeleton**:

- It does not yet wire into existing TypeScript routing code.
- It does not yet include actual Redis / LMDB / Postgres drivers (those are intended to be added next, implementing `IStore`).
- It does not yet replace the existing prompt affinity store; instead it factors out the state machine into a pure function ready to be consumed from `sql-prompt-affinity-store.ts` or its ClojureScript equivalent.

Follow-up steps proposed:

1. Implement Redis, LMDB, and Postgres drivers in ClojureScript (shadow-cljs target), all conforming to `IStore`.
2. Add ingress layer for REST/WS that uses `normalize-keys`, `stamp-provenance`, and `validate` before calling `route!`.
3. Wire the SQL prompt affinity store to use `apply-affinity-event` so the state machine is defined only once.
4. Gradually move existing policy/metric logic (health, suitability, scoring weights, pheromones) into the schema + processor + cache-policy pattern.

This PR is mainly to establish the shapes, naming, and boundaries so that further work can snap into place.

## Notes

- All namespaces are placed under `src/proxx/` to avoid colliding with existing TS code.
- Code is written in a shadow-cljs / ClojureScript style but does not yet modify build config.
- No runtime wiring has been changed; this should be safe to merge without affecting existing behavior.
