### PR TITLE
fix: normalize federation nginx host routing

### DIFF
--- a/deploy/nginx.federation-e2e.conf
+++ b/deploy/nginx.federation-e2e.conf
@@ -38,7 +38,7 @@ http {
     server federation-proxx-b2:8789;
   }
 
-  map $http_host $federation_upstream {
+  map $host $federation_upstream {
     default federation_cluster_all;
     cluster.federation.test federation_cluster_all;
     group-a.federation.test federation_group_a;

--- a/deploy/nginx.federation.runtime.conf
+++ b/deploy/nginx.federation.runtime.conf
@@ -54,7 +54,9 @@ http {
   upstream federation_node_b1_web { server federation-proxx-b1:5174; }
   upstream federation_node_b2_web { server federation-proxx-b2:5174; }
 
-  map $http_host $federation_api_upstream {
+  # Route by normalized host instead of $http_host so node-specific
+  # federation hosts still match when clients/proxies include a port.
+  map $host $federation_api_upstream {
     default federation_cluster_api;
     ~^group-a\. federation_group_a_api;
     ~^group-b\. federation_group_b_api;
@@ -64,7 +66,7 @@ http {
     ~^b2\. federation_node_b2_api;
   }
 
-  map $http_host $federation_web_upstream {
+  map $host $federation_web_upstream {
     default federation_cluster_web;
     ~^group-a\. federation_group_a_web;
     ~^group-b\. federation_group_b_web;


### PR DESCRIPTION
## Summary
- Switch federation nginx host maps from `$http_host` to normalized `$host`.
- Keeps node-specific federation hosts matched even when an upstream proxy/client supplies a Host header with a port.
- Applies the same normalization to runtime and local federation e2e nginx configs.

## Validation
- Inspected live #181 failure: a1/a2 host requests were being routed to the wrong group-a node while b1/b2 were correct.
- Config-only change; staging live e2e will validate after merge to staging.