### PR TITLE
replay: embedding provider strategies

### DIFF
--- a/src/lib/embeddings-providers/index.ts
+++ b/src/lib/embeddings-providers/index.ts
@@ -1,0 +1,168 @@
+/**
+ * embeddings-providers/index.ts
+ *
+ * Provider implementations for each embedding backend.
+ * Each provider function accepts a resolved config + request
+ * and returns a normalised EmbeddingResponse.
+ */
+
+import type {
+  EmbeddingProviderConfig,
+  EmbeddingRequest,
+  EmbeddingResponse,
+} from '../embeddings-strategy.js';
+
+// ---------------------------------------------------------------------------
+// Ollama  (existing path — unchanged semantics)
+// ---------------------------------------------------------------------------
+export async function embedWithOllama(
+  cfg: EmbeddingProviderConfig,
+  req: EmbeddingRequest,
+): Promise<EmbeddingResponse> {
+  const inputs = Array.isArray(req.input) ? req.input : [req.input];
+  const url = `${cfg.endpoint}/api/embed`;
+
+  const res = await fetch(url, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ model: req.model, input: inputs }),
+    signal: AbortSignal.timeout(req.timeoutMs ?? cfg.timeoutMs ?? 30_000),
+  });
+
+  if (!res.ok) throw new Error(`Ollama embed error ${res.status}: ${await res.text()}`);
+
+  const data = (await res.json()) as { embeddings: number[][] };
+  return {
+    provider: 'ollama',
+    model: req.model,
+    embeddings: data.embeddings,
+    dimensions: data.embeddings[0]?.length ?? 0,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Hugging Face cloud  (native HF inference flow, NOT OpenAI compat shim)
+// Docs: https://huggingface.co/docs/inference-providers/en/index
+// ---------------------------------------------------------------------------
+export async function embedWithHFCloud(
+  cfg: EmbeddingProviderConfig,
+  req: EmbeddingRequest,
+): Promise<EmbeddingResponse> {
+  const inputs = Array.isArray(req.input) ? req.input : [req.input];
+  const model = req.model;
+  const url = `${cfg.endpoint}/pipeline/feature-extraction/${encodeURIComponent(model)}`;
+
+  const body: Record<string, unknown> = { inputs };
+  if (req.instruction) body['parameters'] = { prompt: req.instruction };
+  if (req.dimensions) body['parameters'] = { ...(body['parameters'] as object), truncate_dim: req.dimensions };
+
+  const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+  if (cfg.apiKey) headers['Authorization'] = `Bearer ${cfg.apiKey}`;
+
+  const res = await fetch(url, {
+    method: 'POST',
+    headers,
+    body: JSON.stringify(body),
+    signal: AbortSignal.timeout(req.timeoutMs ?? cfg.timeoutMs ?? 30_000),
+  });
+
+  if (!res.ok) throw new Error(`HF cloud embed error ${res.status}: ${await res.text()}`);
+
+  const data = (await res.json()) as number[][] | number[][][];
+  // HF returns shape [batch, dims] or [batch, seq, dims]; normalise to [batch, dims]
+  const embeddings = (data as number[][][]).every(Array.isArray)
+    ? (data as number[][][]).map((seq) => seq[0])
+    : (data as number[][]);
+
+  return {
+    provider: 'huggingface-cloud',
+    model,
+    embeddings,
+    dimensions: embeddings[0]?.length ?? 0,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// TEI  (self-hosted Text Embeddings Inference)
+// Docs: https://github.com/huggingface/text-embeddings-inference
+// Exposes /embed  (TEI native) and /v1/embeddings (OpenAI-compat)
+// We prefer the native /embed endpoint here for full feature parity.
+// ---------------------------------------------------------------------------
+export async function embedWithTEI(
+  cfg: EmbeddingProviderConfig,
+  req: EmbeddingRequest,
+): Promise<EmbeddingResponse> {
+  const inputs = Array.isArray(req.input) ? req.input : [req.input];
+  const url = `${cfg.endpoint}/embed`;
+
+  const body: Record<string, unknown> = { inputs };
+  if (req.dimensions) body['truncate_dim'] = req.dimensions;
+
+  const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+  if (cfg.apiKey) headers['Authorization'] = `Bearer ${cfg.apiKey}`;
+
+  const res = await fetch(url, {
+    method: 'POST',
+    headers,
+    body: JSON.stringify(body),
+    signal: AbortSignal.timeout(req.timeoutMs ?? cfg.timeoutMs ?? 30_000),
+  });
+
+  if (!res.ok) throw new Error(`TEI embed error ${res.status}: ${await res.text()}`);
+
+  const embeddings = (await res.json()) as number[][];
+  return {
+    provider: 'tei',
+    model: req.model,
+    embeddings,
+    dimensions: embeddings[0]?.length ?? 0,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// ovm-npu  (Intel OpenVINO Model Server, /v3/embeddings path)
+// Docs: https://github.com/openvinotoolkit/model_server/blob/main/demos/embeddings/README.md
+// Primary model: OpenVINO/Qwen3-Embedding-0.6B-int8-ov
+// NOTE: ovm-npu is for 0.6B only — use HF cloud or TEI for 4B variants.
+// ---------------------------------------------------------------------------
+export async function embedWithOvmNpu(
+  cfg: EmbeddingProviderConfig,
+  req: EmbeddingRequest,
+): Promise<EmbeddingResponse> {
+  const inputs = Array.isArray(req.input) ? req.input : [req.input];
+  const url = `${cfg.endpoint}/v3/embeddings`;
+
+  const body: Record<string, unknown> = {
+    model: req.model,
+    input: inputs,
+  };
+  if (req.dimensions) body['dimensions'] = req.dimensions;
+
+  const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+  if (cfg.apiKey) headers['Authorization'] = `Bearer ${cfg.apiKey}`;
+
+  const res = await fetch(url, {
+    method: 'POST',
+    headers,
+    body: JSON.stringify(body),
+    signal: AbortSignal.timeout(req.timeoutMs ?? cfg.timeoutMs ?? 30_000),
+  });
+
+  if (!res.ok) throw new Error(`ovm-npu embed error ${res.status}: ${await res.text()}`);
+
+  const data = (await res.json()) as {
+    data: Array<{ embedding: number[]; index: number }>;
+    usage?: { prompt_tokens: number; total_tokens: number };
+  };
+
+  const embeddings = data.data.sort((a, b) => a.index - b.index).map((d) => d.embedding);
+  return {
+    provider: 'ovm-npu',
+    model: req.model,
+    embeddings,
+    dimensions: embeddings[0]?.length ?? 0,
+    usage: data.usage
+      ? { promptTokens: data.usage.prompt_tokens, totalTokens: data.usage.total_tokens }
+      : undefined,
+  };
+}

--- a/src/lib/embeddings-strategy.ts
+++ b/src/lib/embeddings-strategy.ts
@@ -1,0 +1,102 @@
+/**
+ * embeddings-strategy.ts
+ *
+ * Multi-provider embedding strategy for proxx.
+ *
+ * Providers:
+ *   ollama           - existing local path, unchanged default
+ *   huggingface-cloud - HF Inference Providers serverless (free-tier friendly)
+ *   tei              - self-hosted Text Embeddings Inference
+ *   ovm-npu          - Intel OpenVINO Model Server /v3/embeddings (NPU-optimised)
+ *
+ * Model intent:
+ *   ollama           -> any model available via Ollama (e.g. nomic-embed-text)
+ *   huggingface-cloud -> Qwen/Qwen3-Embedding-4B  (routed, free-tier credits)
+ *   tei              -> Qwen/Qwen3-Embedding-4B  (self-hosted TEI)
+ *   ovm-npu          -> OpenVINO/Qwen3-Embedding-0.6B-int8-ov  (NPU local)
+ *
+ * NOTE: HF cloud uses the native HF inference flow, NOT the OpenAI embeddings shim.
+ *       The /v1/embeddings OpenAI-compat route on HF is chat-only at this time.
+ */
+
+export type EmbeddingProvider =
+  | 'ollama'
+  | 'huggingface-cloud'
+  | 'tei'
+  | 'ovm-npu';
+
+export type EmbeddingMode = 'query' | 'document';
+
+export interface EmbeddingRequest {
+  provider: EmbeddingProvider;
+  model: string;
+  input: string | string[];
+  mode?: EmbeddingMode;
+  /** Qwen3 instruction-aware prefix (optional, passed in prompt field) */
+  instruction?: string;
+  /** Truncate output to N dimensions if model supports matryoshka */
+  dimensions?: number;
+  timeoutMs?: number;
+}
+
+export interface EmbeddingResponse {
+  provider: EmbeddingProvider;
+  model: string;
+  embeddings: number[][];
+  dimensions: number;
+  usage?: { promptTokens: number; totalTokens: number };
+}
+
+export interface EmbeddingProviderConfig {
+  endpoint: string;
+  apiKey?: string;
+  defaultModel?: string;
+  defaultDimensions?: number;
+  timeoutMs?: number;
+}
+
+/** Per-provider config, loaded from env (see .env.example additions) */
+export interface EmbeddingsConfig {
+  ollama: EmbeddingProviderConfig;
+  'huggingface-cloud': EmbeddingProviderConfig;
+  tei: EmbeddingProviderConfig;
+  'ovm-npu': EmbeddingProviderConfig;
+  defaultProvider: EmbeddingProvider;
+  fallbackProvider?: EmbeddingProvider;
+}
+
+export function loadEmbeddingsConfig(): EmbeddingsConfig {
+  return {
+    ollama: {
+      endpoint: process.env.OLLAMA_ENDPOINT ?? 'http://localhost:11434',
+      defaultModel: process.env.OLLAMA_EMBED_MODEL ?? 'nomic-embed-text',
+    },
+    'huggingface-cloud': {
+      endpoint: process.env.HF_INFERENCE_ENDPOINT ?? 'https://api-inference.huggingface.co',
+      apiKey: process.env.HF_API_KEY,
+      defaultModel: process.env.HF_EMBED_MODEL ?? 'Qwen/Qwen3-Embedding-4B',
+      defaultDimensions: process.env.HF_EMBED_DIMENSIONS
+        ? parseInt(process.env.HF_EMBED_DIMENSIONS, 10)
+        : undefined,
+    },
+    tei: {
+      endpoint: process.env.TEI_ENDPOINT ?? 'http://localhost:8080',
+      apiKey: process.env.TEI_API_KEY,
+      defaultModel: process.env.TEI_EMBED_MODEL ?? 'Qwen/Qwen3-Embedding-4B',
+      defaultDimensions: process.env.TEI_EMBED_DIMENSIONS
+        ? parseInt(process.env.TEI_EMBED_DIMENSIONS, 10)
+        : undefined,
+    },
+    'ovm-npu': {
+      endpoint: process.env.OVM_NPU_ENDPOINT ?? 'http://localhost:9000',
+      apiKey: process.env.OVM_NPU_API_KEY,
+      defaultModel:
+        process.env.OVM_NPU_EMBED_MODEL ?? 'OpenVINO/Qwen3-Embedding-0.6B-int8-ov',
+      defaultDimensions: process.env.OVM_NPU_EMBED_DIMENSIONS
+        ? parseInt(process.env.OVM_NPU_EMBED_DIMENSIONS, 10)
+        : undefined,
+    },
+    defaultProvider: (process.env.EMBED_DEFAULT_PROVIDER as EmbeddingProvider) ?? 'ollama',
+    fallbackProvider: process.env.EMBED_FALLBACK_PROVIDER as EmbeddingProvider | undefined,
+  };
+}

--- a/src/lib/policy/schema.ts
+++ b/src/lib/policy/schema.ts
@@ -36,7 +36,10 @@ export type UpstreamMode =
   | "gemini_chat"
   | "ollama_chat"
   | "local_ollama_chat"
-  | "embeddings";
+  | "embeddings"
+  | "hf_embeddings"
+  | "tei_embeddings"
+  | "ovm_embeddings";
 
 export interface StrategyInfo {
   readonly mode: UpstreamMode;

--- a/src/lib/provider-strategy/registry.ts
+++ b/src/lib/provider-strategy/registry.ts
@@ -8,7 +8,7 @@ import { LocalOllamaProviderStrategy, OllamaProviderStrategy } from "./strategie
 import { OllamaCloudProviderStrategy } from "./strategies/ollama-cloud.js";
 import { ChatCompletionsProviderStrategy, ImagesGenerationsPassthroughStrategy, MessagesProviderStrategy, ResponsesPassthroughStrategy, ResponsesProviderStrategy, ResponsesViaChatCompletionsStrategy, ZaiChatCompletionsProviderStrategy } from "./strategies/standard.js";
 import { LlamacppChatCompletionsProviderStrategy } from "./strategies/llamacpp.js";
-import { OpenAiCompatEmbeddingsStrategy, OllamaEmbeddingsStrategy } from "./strategies/embeddings.js";
+import { HuggingFaceEmbeddingStrategy, OpenAiCompatEmbeddingsStrategy, OllamaEmbeddingsStrategy, OvmNpuEmbeddingStrategy, TEIEmbeddingStrategy } from "./strategies/embeddings.js";
 
 export const GEMINI_CHAT_STRATEGY = new GeminiChatProviderStrategy();
 export const ZAI_CHAT_STRATEGY = new ZaiChatCompletionsProviderStrategy();
@@ -19,6 +19,9 @@ export const OPENAI_COMPAT_EMBEDDINGS_STRATEGY = new OpenAiCompatEmbeddingsStrat
 export const OLLAMA_EMBEDDINGS_STRATEGY = new OllamaEmbeddingsStrategy();
 
 export const PROVIDER_STRATEGIES: readonly ProviderStrategy[] = [
+  new HuggingFaceEmbeddingStrategy(),
+  new TEIEmbeddingStrategy(),
+  new OvmNpuEmbeddingStrategy(),
   new ImagesGenerationsPassthroughStrategy(),
   new OpenAiResponsesPassthroughStrategy(),
   new FactoryResponsesPassthroughStrategy(),

--- a/src/lib/provider-strategy/shared.ts
+++ b/src/lib/provider-strategy/shared.ts
@@ -159,7 +159,10 @@ type UpstreamMode =
   | "openai_responses"
   | "ollama_chat"
   | "local_ollama_chat"
-  | "embeddings";
+  | "embeddings"
+  | "hf_embeddings"
+  | "tei_embeddings"
+  | "ovm_embeddings";
 
 interface StrategyRequestContext {
   /** Provider id for which we're selecting an upstream strategy. */

--- a/src/lib/provider-strategy/strategies/embeddings.ts
+++ b/src/lib/provider-strategy/strategies/embeddings.ts
@@ -1,7 +1,9 @@
 import type { FastifyReply } from "fastify";
+import { copyUpstreamHeaders } from "../../proxy.js";
 import { BaseProviderStrategy } from "../base.js";
 import {
   buildPayloadResult,
+  isRecord,
   type BuildPayloadResult,
   type LocalAttemptContext,
   type ProviderAttemptContext,
@@ -18,6 +20,45 @@ export const OPENAI_COMPAT_EMBED_PROVIDERS = new Set(["llamacpp-embed", "llamacp
 
 export function isOpenAiCompatEmbedProvider(providerId: string): boolean {
   return OPENAI_COMPAT_EMBED_PROVIDERS.has(providerId.trim().toLowerCase());
+}
+
+function requestLooksLikeEmbedding(context: StrategyRequestContext): boolean {
+  const body = context.requestBody;
+  return context.embeddingsPassthrough === true
+    || (isRecord(body) && "input" in body && !("messages" in body));
+}
+
+function readEmbeddingProviderHeader(context: StrategyRequestContext): string | undefined {
+  const raw = context.clientHeaders["x-embedding-provider"];
+  const value = Array.isArray(raw) ? raw[0] : raw;
+  return value?.trim().toLowerCase();
+}
+
+async function handleNativeEmbeddingAttempt(
+  reply: FastifyReply,
+  response: Response,
+  _context: ProviderAttemptContext,
+): Promise<ProviderAttemptOutcome> {
+  if (!response.ok) {
+    return { kind: "continue", requestError: true };
+  }
+
+  reply.code(response.status);
+  copyUpstreamHeaders(reply, response.headers);
+  reply.header("content-type", response.headers.get("content-type") ?? "application/json");
+  reply.send(await response.text());
+  return { kind: "handled" };
+}
+
+async function handleNativeEmbeddingLocalAttempt(
+  reply: FastifyReply,
+  response: Response,
+  _context: LocalAttemptContext,
+): Promise<void> {
+  reply.code(response.status);
+  copyUpstreamHeaders(reply, response.headers);
+  reply.header("content-type", response.headers.get("content-type") ?? "application/json");
+  reply.send(await response.text());
 }
 
 /**
@@ -99,5 +140,159 @@ export class OllamaEmbeddingsStrategy extends BaseProviderStrategy {
     context: LocalAttemptContext,
   ): Promise<void> {
     return super.handleLocalAttempt(reply, response, context);
+  }
+}
+
+/**
+ * Hugging Face cloud native feature-extraction strategy.
+ * Uses /pipeline/feature-extraction/<model>, not the OpenAI shim.
+ */
+export class HuggingFaceEmbeddingStrategy extends BaseProviderStrategy {
+  public readonly mode = "hf_embeddings" as const;
+  public readonly isLocal = false;
+
+  public matches(context: StrategyRequestContext): boolean {
+    if (!requestLooksLikeEmbedding(context)) {
+      return false;
+    }
+    const provider = readEmbeddingProviderHeader(context);
+    return provider === "huggingface" || provider === "hf" || provider === "hf_embeddings";
+  }
+
+  public getUpstreamPath(context: StrategyRequestContext): string {
+    const model = typeof context.requestBody.model === "string"
+      ? context.requestBody.model
+      : "Qwen/Qwen3-Embedding-4B";
+    return `/pipeline/feature-extraction/${encodeURIComponent(model)}`;
+  }
+
+  public buildPayload(context: StrategyRequestContext): BuildPayloadResult {
+    const inputs = context.requestBody.input;
+    const payload: Record<string, unknown> = {
+      inputs: Array.isArray(inputs) ? inputs : [inputs],
+    };
+    if (context.requestBody.instruction !== undefined) {
+      payload.parameters = { prompt: context.requestBody.instruction };
+    }
+    if (context.requestBody.dimensions !== undefined) {
+      payload.parameters = {
+        ...(isRecord(payload.parameters) ? payload.parameters : {}),
+        truncate_dim: context.requestBody.dimensions,
+      };
+    }
+    return buildPayloadResult(payload, context);
+  }
+
+  public override async handleProviderAttempt(
+    reply: FastifyReply,
+    response: Response,
+    context: ProviderAttemptContext,
+  ): Promise<ProviderAttemptOutcome> {
+    return handleNativeEmbeddingAttempt(reply, response, context);
+  }
+
+  public override async handleLocalAttempt(
+    reply: FastifyReply,
+    response: Response,
+    context: LocalAttemptContext,
+  ): Promise<void> {
+    await handleNativeEmbeddingLocalAttempt(reply, response, context);
+  }
+}
+
+/**
+ * Hugging Face Text Embeddings Inference strategy for native /embed.
+ */
+export class TEIEmbeddingStrategy extends BaseProviderStrategy {
+  public readonly mode = "tei_embeddings" as const;
+  public readonly isLocal = false;
+
+  public matches(context: StrategyRequestContext): boolean {
+    if (!requestLooksLikeEmbedding(context)) {
+      return false;
+    }
+    const provider = readEmbeddingProviderHeader(context);
+    return provider === "tei" || provider === "tei_embeddings";
+  }
+
+  public getUpstreamPath(_context: StrategyRequestContext): string {
+    return "/embed";
+  }
+
+  public buildPayload(context: StrategyRequestContext): BuildPayloadResult {
+    const inputs = context.requestBody.input;
+    const payload: Record<string, unknown> = {
+      inputs: Array.isArray(inputs) ? inputs : [inputs],
+    };
+    if (context.requestBody.dimensions !== undefined) {
+      payload.truncate_dim = context.requestBody.dimensions;
+    }
+    return buildPayloadResult(payload, context);
+  }
+
+  public override async handleProviderAttempt(
+    reply: FastifyReply,
+    response: Response,
+    context: ProviderAttemptContext,
+  ): Promise<ProviderAttemptOutcome> {
+    return handleNativeEmbeddingAttempt(reply, response, context);
+  }
+
+  public override async handleLocalAttempt(
+    reply: FastifyReply,
+    response: Response,
+    context: LocalAttemptContext,
+  ): Promise<void> {
+    await handleNativeEmbeddingLocalAttempt(reply, response, context);
+  }
+}
+
+/**
+ * Intel OpenVINO Model Server embeddings strategy for /v3/embeddings.
+ */
+export class OvmNpuEmbeddingStrategy extends BaseProviderStrategy {
+  public readonly mode = "ovm_embeddings" as const;
+  public readonly isLocal = false;
+
+  public matches(context: StrategyRequestContext): boolean {
+    if (!requestLooksLikeEmbedding(context)) {
+      return false;
+    }
+    const provider = readEmbeddingProviderHeader(context);
+    return provider === "ovm" || provider === "ovm-npu" || provider === "ovm_embeddings";
+  }
+
+  public getUpstreamPath(_context: StrategyRequestContext): string {
+    return "/v3/embeddings";
+  }
+
+  public buildPayload(context: StrategyRequestContext): BuildPayloadResult {
+    const inputs = context.requestBody.input;
+    const payload: Record<string, unknown> = {
+      model: typeof context.requestBody.model === "string"
+        ? context.requestBody.model
+        : "OpenVINO/Qwen3-Embedding-0.6B-int8-ov",
+      input: Array.isArray(inputs) ? inputs : [inputs],
+    };
+    if (context.requestBody.dimensions !== undefined) {
+      payload.dimensions = context.requestBody.dimensions;
+    }
+    return buildPayloadResult(payload, context);
+  }
+
+  public override async handleProviderAttempt(
+    reply: FastifyReply,
+    response: Response,
+    context: ProviderAttemptContext,
+  ): Promise<ProviderAttemptOutcome> {
+    return handleNativeEmbeddingAttempt(reply, response, context);
+  }
+
+  public override async handleLocalAttempt(
+    reply: FastifyReply,
+    response: Response,
+    context: LocalAttemptContext,
+  ): Promise<void> {
+    await handleNativeEmbeddingLocalAttempt(reply, response, context);
   }
 }

--- a/src/tests/embeddings-strategy.test.ts
+++ b/src/tests/embeddings-strategy.test.ts
@@ -1,196 +1,164 @@
 /**
  * embeddings-strategy.test.ts
  *
- * Conformance and sanity tests for the multi-provider embedding strategy.
- * All provider calls are mocked — no live endpoints required.
+ * Conformance tests for the embedding ProviderStrategy subclasses.
+ * Uses the same strategy interface as all other proxx strategies.
  */
 
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
 import {
-  embedWithOllama,
-  embedWithHFCloud,
-  embedWithTEI,
-  embedWithOvmNpu,
-} from '../lib/embeddings-providers/index.js';
-import type { EmbeddingProviderConfig, EmbeddingRequest } from '../lib/embeddings-strategy.js';
+  HuggingFaceEmbeddingStrategy,
+  TEIEmbeddingStrategy,
+  OvmNpuEmbeddingStrategy,
+} from '../lib/provider-strategy/strategies/embeddings.js';
+import type { StrategyRequestContext } from '../lib/provider-strategy/shared.js';
 
-const MOCK_DIMS = 1024;
-const mockEmbedding = Array.from({ length: MOCK_DIMS }, (_, i) => i / MOCK_DIMS);
-
-function makeCfg(overrides?: Partial<EmbeddingProviderConfig>): EmbeddingProviderConfig {
-  return { endpoint: 'http://mock', apiKey: 'test-key', ...overrides };
-}
-
-function makeReq(overrides?: Partial<EmbeddingRequest>): EmbeddingRequest {
+// ---------------------------------------------------------------------------
+// Minimal mock context
+// ---------------------------------------------------------------------------
+function makeCtx(overrides: Partial<StrategyRequestContext> = {}): StrategyRequestContext {
   return {
-    provider: 'ollama',
-    model: 'test-model',
-    input: ['hello world'],
-    mode: 'query',
+    config: {} as never,
+    clientHeaders: {},
+    requestBody: { input: ['hello world'] },
+    requestedModelInput: 'test-model',
+    routingModelInput: 'test-model',
+    routedModel: 'test-model',
+    explicitOllama: false,
+    openAiPrefixed: false,
+    factoryPrefixed: false,
+    localOllama: false,
+    clientWantsStream: false,
+    needsReasoningTrace: false,
+    upstreamAttemptTimeoutMs: 30_000,
     ...overrides,
   };
 }
 
-beforeEach(() => vi.restoreAllMocks());
+function embedCtx(provider: string, extra?: Partial<StrategyRequestContext>): StrategyRequestContext {
+  return makeCtx({
+    clientHeaders: { 'x-embedding-provider': provider },
+    requestBody: { input: ['hello'] },
+    ...extra,
+  });
+}
 
 // ---------------------------------------------------------------------------
-// Ollama
+// HuggingFaceEmbeddingStrategy
 // ---------------------------------------------------------------------------
-describe('embedWithOllama', () => {
-  it('returns normalised EmbeddingResponse', async () => {
-    vi.stubGlobal('fetch', async () => ({
-      ok: true,
-      json: async () => ({ embeddings: [mockEmbedding] }),
-    }));
+describe('HuggingFaceEmbeddingStrategy', () => {
+  const s = new HuggingFaceEmbeddingStrategy();
 
-    const res = await embedWithOllama(makeCfg(), makeReq({ provider: 'ollama' }));
-    expect(res.provider).toBe('ollama');
-    expect(res.embeddings).toHaveLength(1);
-    expect(res.dimensions).toBe(MOCK_DIMS);
+  it('has mode hf_embeddings', () => assert.equal(s.mode, 'hf_embeddings'));
+  it('is not local', () => assert.equal(s.isLocal, false));
+
+  it('matches on x-embedding-provider: hf', () =>
+    assert.equal(s.matches(embedCtx('hf')), true));
+  it('matches on x-embedding-provider: huggingface', () =>
+    assert.equal(s.matches(embedCtx('huggingface')), true));
+  it('does not match tei', () =>
+    assert.equal(s.matches(embedCtx('tei')), false));
+
+  it('getUpstreamPath encodes model name', () => {
+    const ctx = embedCtx('hf', { requestBody: { input: ['x'], model: 'Qwen/Qwen3-Embedding-4B' } });
+    assert.equal(s.getUpstreamPath(ctx), '/pipeline/feature-extraction/Qwen%2FQwen3-Embedding-4B');
   });
 
-  it('throws on non-ok response', async () => {
-    vi.stubGlobal('fetch', async () => ({ ok: false, status: 500, text: async () => 'err' }));
-    await expect(embedWithOllama(makeCfg(), makeReq())).rejects.toThrow('500');
-  });
-});
-
-// ---------------------------------------------------------------------------
-// Hugging Face cloud  (native inference, not OpenAI shim)
-// ---------------------------------------------------------------------------
-describe('embedWithHFCloud', () => {
-  it('returns normalised EmbeddingResponse', async () => {
-    vi.stubGlobal('fetch', async () => ({
-      ok: true,
-      json: async () => [mockEmbedding],
-    }));
-
-    const res = await embedWithHFCloud(
-      makeCfg(),
-      makeReq({ provider: 'huggingface-cloud', model: 'Qwen/Qwen3-Embedding-4B' }),
-    );
-    expect(res.provider).toBe('huggingface-cloud');
-    expect(res.model).toBe('Qwen/Qwen3-Embedding-4B');
-    expect(res.dimensions).toBe(MOCK_DIMS);
+  it('getUpstreamPath does NOT contain /v1/embeddings', () => {
+    const ctx = embedCtx('hf');
+    assert.equal(s.getUpstreamPath(ctx).includes('/v1/embeddings'), false);
   });
 
-  it('sends Authorization header when apiKey present', async () => {
-    let capturedHeaders: Record<string, string> = {};
-    vi.stubGlobal('fetch', async (_url: string, opts: RequestInit) => {
-      capturedHeaders = opts.headers as Record<string, string>;
-      return { ok: true, json: async () => [mockEmbedding] };
-    });
-
-    await embedWithHFCloud(makeCfg({ apiKey: 'hf_test' }), makeReq({ provider: 'huggingface-cloud' }));
-    expect(capturedHeaders['Authorization']).toBe('Bearer hf_test');
+  it('buildPayload wraps scalar input in array', () => {
+    const ctx = embedCtx('hf', { requestBody: { input: 'single string' } });
+    const result = s.buildPayload(ctx);
+    assert.equal(Array.isArray(result.upstreamPayload['inputs']), true);
   });
 
-  it('does NOT hit /v1/embeddings (OpenAI shim)', async () => {
-    let capturedUrl = '';
-    vi.stubGlobal('fetch', async (url: string) => {
-      capturedUrl = url;
-      return { ok: true, json: async () => [mockEmbedding] };
-    });
-
-    await embedWithHFCloud(makeCfg(), makeReq({ provider: 'huggingface-cloud' }));
-    expect(capturedUrl).not.toContain('/v1/embeddings');
-    expect(capturedUrl).toContain('/pipeline/feature-extraction/');
+  it('buildPayload forwards instruction as parameters.prompt', () => {
+    const ctx = embedCtx('hf', { requestBody: { input: ['x'], instruction: 'Embed this' } });
+    const result = s.buildPayload(ctx);
+    const params = result.upstreamPayload['parameters'] as Record<string, unknown>;
+    assert.equal(params['prompt'], 'Embed this');
   });
 });
 
 // ---------------------------------------------------------------------------
-// TEI (self-hosted)
+// TEIEmbeddingStrategy
 // ---------------------------------------------------------------------------
-describe('embedWithTEI', () => {
-  it('returns normalised EmbeddingResponse', async () => {
-    vi.stubGlobal('fetch', async () => ({
-      ok: true,
-      json: async () => [mockEmbedding],
-    }));
+describe('TEIEmbeddingStrategy', () => {
+  const s = new TEIEmbeddingStrategy();
 
-    const res = await embedWithTEI(
-      makeCfg(),
-      makeReq({ provider: 'tei', model: 'Qwen/Qwen3-Embedding-4B' }),
-    );
-    expect(res.provider).toBe('tei');
-    expect(res.model).toBe('Qwen/Qwen3-Embedding-4B');
-    expect(res.dimensions).toBe(MOCK_DIMS);
-  });
+  it('has mode tei_embeddings', () => assert.equal(s.mode, 'tei_embeddings'));
+  it('is not local', () => assert.equal(s.isLocal, false));
 
-  it('uses /embed not /v1/embeddings', async () => {
-    let capturedUrl = '';
-    vi.stubGlobal('fetch', async (url: string) => {
-      capturedUrl = url;
-      return { ok: true, json: async () => [mockEmbedding] };
-    });
+  it('matches on x-embedding-provider: tei', () =>
+    assert.equal(s.matches(embedCtx('tei')), true));
+  it('does not match hf', () =>
+    assert.equal(s.matches(embedCtx('hf')), false));
 
-    await embedWithTEI(makeCfg(), makeReq({ provider: 'tei' }));
-    expect(capturedUrl).toMatch(/\/embed$/);
+  it('getUpstreamPath returns /embed', () =>
+    assert.equal(s.getUpstreamPath(makeCtx()), '/embed'));
+
+  it('getUpstreamPath does NOT contain /v1/embeddings', () =>
+    assert.equal(s.getUpstreamPath(makeCtx()).includes('/v1/embeddings'), false));
+
+  it('buildPayload sets truncate_dim when dimensions provided', () => {
+    const ctx = embedCtx('tei', { requestBody: { input: ['x'], dimensions: 512 } });
+    const result = s.buildPayload(ctx);
+    assert.equal(result.upstreamPayload['truncate_dim'], 512);
   });
 });
 
 // ---------------------------------------------------------------------------
-// ovm-npu  (Intel OpenVINO Model Server)
+// OvmNpuEmbeddingStrategy
 // ---------------------------------------------------------------------------
-describe('embedWithOvmNpu', () => {
-  const ovmResponse = {
-    data: [{ embedding: mockEmbedding, index: 0 }],
-    usage: { prompt_tokens: 5, total_tokens: 5 },
-  };
+describe('OvmNpuEmbeddingStrategy', () => {
+  const s = new OvmNpuEmbeddingStrategy();
 
-  it('returns normalised EmbeddingResponse', async () => {
-    vi.stubGlobal('fetch', async () => ({
-      ok: true,
-      json: async () => ovmResponse,
-    }));
+  it('has mode ovm_embeddings', () => assert.equal(s.mode, 'ovm_embeddings'));
+  it('is not local', () => assert.equal(s.isLocal, false));
 
-    const res = await embedWithOvmNpu(
-      makeCfg(),
-      makeReq({ provider: 'ovm-npu', model: 'OpenVINO/Qwen3-Embedding-0.6B-int8-ov' }),
-    );
-    expect(res.provider).toBe('ovm-npu');
-    expect(res.model).toBe('OpenVINO/Qwen3-Embedding-0.6B-int8-ov');
-    expect(res.dimensions).toBe(MOCK_DIMS);
-    expect(res.usage?.promptTokens).toBe(5);
+  it('matches on x-embedding-provider: ovm', () =>
+    assert.equal(s.matches(embedCtx('ovm')), true));
+  it('matches on x-embedding-provider: ovm-npu', () =>
+    assert.equal(s.matches(embedCtx('ovm-npu')), true));
+  it('does not match tei', () =>
+    assert.equal(s.matches(embedCtx('tei')), false));
+
+  it('getUpstreamPath returns /v3/embeddings', () =>
+    assert.equal(s.getUpstreamPath(makeCtx()), '/v3/embeddings'));
+
+  it('buildPayload uses 0.6B model by default', () => {
+    const ctx = embedCtx('ovm');
+    const result = s.buildPayload(ctx);
+    assert.equal(String(result.upstreamPayload['model']).includes('0.6B'), true);
   });
 
-  it('hits /v3/embeddings', async () => {
-    let capturedUrl = '';
-    vi.stubGlobal('fetch', async (url: string) => {
-      capturedUrl = url;
-      return { ok: true, json: async () => ovmResponse };
-    });
-
-    await embedWithOvmNpu(makeCfg(), makeReq({ provider: 'ovm-npu' }));
-    expect(capturedUrl).toContain('/v3/embeddings');
-  });
-
-  it('sorts embeddings by index', async () => {
-    vi.stubGlobal('fetch', async () => ({
-      ok: true,
-      json: async () => ({
-        data: [
-          { embedding: [0.9, 0.9], index: 1 },
-          { embedding: [0.1, 0.1], index: 0 },
-        ],
-      }),
-    }));
-
-    const res = await embedWithOvmNpu(makeCfg(), makeReq({ provider: 'ovm-npu' }));
-    expect(res.embeddings[0][0]).toBeCloseTo(0.1);
-    expect(res.embeddings[1][0]).toBeCloseTo(0.9);
+  it('Qwen3-Embedding-4B is NOT the ovm default (route to hf/tei instead)', () => {
+    const ctx = embedCtx('ovm');
+    const result = s.buildPayload(ctx);
+    assert.equal(String(result.upstreamPayload['model']).includes('4B'), false);
   });
 });
 
 // ---------------------------------------------------------------------------
-// Provider isolation — ovm-npu should NOT be used for 4B models
+// Registration guard: embedding strategies must not accidentally match chat
 // ---------------------------------------------------------------------------
-describe('provider intent guards', () => {
-  it('Qwen3-Embedding-4B should route to hf-cloud or tei, not ovm-npu', () => {
-    const model = 'Qwen/Qwen3-Embedding-4B';
-    // ovm-npu default model is the 0.6B variant
-    const ovmDefault = 'OpenVINO/Qwen3-Embedding-0.6B-int8-ov';
-    expect(model).not.toBe(ovmDefault);
-    expect(model).not.toContain('0.6B');
+describe('embedding strategies do not match chat requests', () => {
+  const strategies = [
+    new HuggingFaceEmbeddingStrategy(),
+    new TEIEmbeddingStrategy(),
+    new OvmNpuEmbeddingStrategy(),
+  ];
+
+  it('none match a plain chat request body', () => {
+    const chatCtx = makeCtx({
+      requestBody: { messages: [{ role: 'user', content: 'hi' }] },
+    });
+    for (const s of strategies) {
+      assert.equal(s.matches(chatCtx), false);
+    }
   });
 });

--- a/src/tests/embeddings-strategy.test.ts
+++ b/src/tests/embeddings-strategy.test.ts
@@ -1,0 +1,196 @@
+/**
+ * embeddings-strategy.test.ts
+ *
+ * Conformance and sanity tests for the multi-provider embedding strategy.
+ * All provider calls are mocked — no live endpoints required.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+  embedWithOllama,
+  embedWithHFCloud,
+  embedWithTEI,
+  embedWithOvmNpu,
+} from '../lib/embeddings-providers/index.js';
+import type { EmbeddingProviderConfig, EmbeddingRequest } from '../lib/embeddings-strategy.js';
+
+const MOCK_DIMS = 1024;
+const mockEmbedding = Array.from({ length: MOCK_DIMS }, (_, i) => i / MOCK_DIMS);
+
+function makeCfg(overrides?: Partial<EmbeddingProviderConfig>): EmbeddingProviderConfig {
+  return { endpoint: 'http://mock', apiKey: 'test-key', ...overrides };
+}
+
+function makeReq(overrides?: Partial<EmbeddingRequest>): EmbeddingRequest {
+  return {
+    provider: 'ollama',
+    model: 'test-model',
+    input: ['hello world'],
+    mode: 'query',
+    ...overrides,
+  };
+}
+
+beforeEach(() => vi.restoreAllMocks());
+
+// ---------------------------------------------------------------------------
+// Ollama
+// ---------------------------------------------------------------------------
+describe('embedWithOllama', () => {
+  it('returns normalised EmbeddingResponse', async () => {
+    vi.stubGlobal('fetch', async () => ({
+      ok: true,
+      json: async () => ({ embeddings: [mockEmbedding] }),
+    }));
+
+    const res = await embedWithOllama(makeCfg(), makeReq({ provider: 'ollama' }));
+    expect(res.provider).toBe('ollama');
+    expect(res.embeddings).toHaveLength(1);
+    expect(res.dimensions).toBe(MOCK_DIMS);
+  });
+
+  it('throws on non-ok response', async () => {
+    vi.stubGlobal('fetch', async () => ({ ok: false, status: 500, text: async () => 'err' }));
+    await expect(embedWithOllama(makeCfg(), makeReq())).rejects.toThrow('500');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Hugging Face cloud  (native inference, not OpenAI shim)
+// ---------------------------------------------------------------------------
+describe('embedWithHFCloud', () => {
+  it('returns normalised EmbeddingResponse', async () => {
+    vi.stubGlobal('fetch', async () => ({
+      ok: true,
+      json: async () => [mockEmbedding],
+    }));
+
+    const res = await embedWithHFCloud(
+      makeCfg(),
+      makeReq({ provider: 'huggingface-cloud', model: 'Qwen/Qwen3-Embedding-4B' }),
+    );
+    expect(res.provider).toBe('huggingface-cloud');
+    expect(res.model).toBe('Qwen/Qwen3-Embedding-4B');
+    expect(res.dimensions).toBe(MOCK_DIMS);
+  });
+
+  it('sends Authorization header when apiKey present', async () => {
+    let capturedHeaders: Record<string, string> = {};
+    vi.stubGlobal('fetch', async (_url: string, opts: RequestInit) => {
+      capturedHeaders = opts.headers as Record<string, string>;
+      return { ok: true, json: async () => [mockEmbedding] };
+    });
+
+    await embedWithHFCloud(makeCfg({ apiKey: 'hf_test' }), makeReq({ provider: 'huggingface-cloud' }));
+    expect(capturedHeaders['Authorization']).toBe('Bearer hf_test');
+  });
+
+  it('does NOT hit /v1/embeddings (OpenAI shim)', async () => {
+    let capturedUrl = '';
+    vi.stubGlobal('fetch', async (url: string) => {
+      capturedUrl = url;
+      return { ok: true, json: async () => [mockEmbedding] };
+    });
+
+    await embedWithHFCloud(makeCfg(), makeReq({ provider: 'huggingface-cloud' }));
+    expect(capturedUrl).not.toContain('/v1/embeddings');
+    expect(capturedUrl).toContain('/pipeline/feature-extraction/');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// TEI (self-hosted)
+// ---------------------------------------------------------------------------
+describe('embedWithTEI', () => {
+  it('returns normalised EmbeddingResponse', async () => {
+    vi.stubGlobal('fetch', async () => ({
+      ok: true,
+      json: async () => [mockEmbedding],
+    }));
+
+    const res = await embedWithTEI(
+      makeCfg(),
+      makeReq({ provider: 'tei', model: 'Qwen/Qwen3-Embedding-4B' }),
+    );
+    expect(res.provider).toBe('tei');
+    expect(res.model).toBe('Qwen/Qwen3-Embedding-4B');
+    expect(res.dimensions).toBe(MOCK_DIMS);
+  });
+
+  it('uses /embed not /v1/embeddings', async () => {
+    let capturedUrl = '';
+    vi.stubGlobal('fetch', async (url: string) => {
+      capturedUrl = url;
+      return { ok: true, json: async () => [mockEmbedding] };
+    });
+
+    await embedWithTEI(makeCfg(), makeReq({ provider: 'tei' }));
+    expect(capturedUrl).toMatch(/\/embed$/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ovm-npu  (Intel OpenVINO Model Server)
+// ---------------------------------------------------------------------------
+describe('embedWithOvmNpu', () => {
+  const ovmResponse = {
+    data: [{ embedding: mockEmbedding, index: 0 }],
+    usage: { prompt_tokens: 5, total_tokens: 5 },
+  };
+
+  it('returns normalised EmbeddingResponse', async () => {
+    vi.stubGlobal('fetch', async () => ({
+      ok: true,
+      json: async () => ovmResponse,
+    }));
+
+    const res = await embedWithOvmNpu(
+      makeCfg(),
+      makeReq({ provider: 'ovm-npu', model: 'OpenVINO/Qwen3-Embedding-0.6B-int8-ov' }),
+    );
+    expect(res.provider).toBe('ovm-npu');
+    expect(res.model).toBe('OpenVINO/Qwen3-Embedding-0.6B-int8-ov');
+    expect(res.dimensions).toBe(MOCK_DIMS);
+    expect(res.usage?.promptTokens).toBe(5);
+  });
+
+  it('hits /v3/embeddings', async () => {
+    let capturedUrl = '';
+    vi.stubGlobal('fetch', async (url: string) => {
+      capturedUrl = url;
+      return { ok: true, json: async () => ovmResponse };
+    });
+
+    await embedWithOvmNpu(makeCfg(), makeReq({ provider: 'ovm-npu' }));
+    expect(capturedUrl).toContain('/v3/embeddings');
+  });
+
+  it('sorts embeddings by index', async () => {
+    vi.stubGlobal('fetch', async () => ({
+      ok: true,
+      json: async () => ({
+        data: [
+          { embedding: [0.9, 0.9], index: 1 },
+          { embedding: [0.1, 0.1], index: 0 },
+        ],
+      }),
+    }));
+
+    const res = await embedWithOvmNpu(makeCfg(), makeReq({ provider: 'ovm-npu' }));
+    expect(res.embeddings[0][0]).toBeCloseTo(0.1);
+    expect(res.embeddings[1][0]).toBeCloseTo(0.9);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Provider isolation — ovm-npu should NOT be used for 4B models
+// ---------------------------------------------------------------------------
+describe('provider intent guards', () => {
+  it('Qwen3-Embedding-4B should route to hf-cloud or tei, not ovm-npu', () => {
+    const model = 'Qwen/Qwen3-Embedding-4B';
+    // ovm-npu default model is the 0.6B variant
+    const ovmDefault = 'OpenVINO/Qwen3-Embedding-0.6B-int8-ov';
+    expect(model).not.toBe(ovmDefault);
+    expect(model).not.toContain('0.6B');
+  });
+});


### PR DESCRIPTION
## Summary
- Replays the useful PR #180 embedding strategy work onto current staging.
- Adds HF cloud, TEI, and ovm-npu embedding ProviderStrategy subclasses.
- Preserves existing staging OpenAI-compatible and Ollama embedding strategies.
- Widens provider/policy UpstreamMode unions and registers new strategies before chat strategies.
- Converts the replayed embedding strategy tests to node:test so they run in this repository test harness.

## Validation
- pnpm -s typecheck
- pnpm -s lint:errors
- pnpm -s build
- node --test --test-concurrency=1 dist/tests/embeddings-strategy.test.js
- pnpm -s test

## Supersedes
- Salvages and replaces PR #180.