### PR TITLE
fix: restart remote deploy services in order

### DIFF
--- a/scripts/deploy-remote.sh
+++ b/scripts/deploy-remote.sh
@@ -354,7 +354,9 @@ else
 fi
 if [[ -n "$DEPLOY_RESTART_SERVICES" ]]; then
   IFS=',' read -r -a restart_services <<< "$DEPLOY_RESTART_SERVICES"
-  docker compose "${compose_args[@]}" restart "${restart_services[@]}"
+  for service in "${restart_services[@]}"; do
+    [[ -n "$service" ]] && docker compose "${compose_args[@]}" restart "$service"
+  done
 fi
 EOF
 }


### PR DESCRIPTION
## Summary
- Restarts deploy services sequentially in the configured order instead of passing the whole list to docker compose restart.
- Keeps app services before nginx/ssl in deploy workflows so nginx resolves fresh container addresses after app rebuilds.

## Validation
- bash -n scripts/deploy-remote.sh

## Context
- After the Docker prune deploy fix, staging live e2e still observed a1/a2 host routing swapped, consistent with nginx retaining stale upstream resolutions after app containers were recreated.