### PR TITLE
Fix staging CLJS lint findings

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -1,3 +1,4 @@
 {:lint-as {proxx.macros/defn-async clojure.core/defn
            proxx.macros/p-let     clojure.core/let
-           proxx.macros/p->       clojure.core/->}}
+           proxx.macros/p->       clojure.core/->}
+ :linters {:unresolved-symbol {:exclude [await]}}}

--- a/src/proxx/policy/contracts.cljs
+++ b/src/proxx/policy/contracts.cljs
@@ -933,7 +933,7 @@
              :model-id model-id
              :route-id (:contract/id route)
              :providers []}
-            (if-let [missing-route (first (missing-provider-route-ids compiled ordered-providers))]
+            (if (seq (missing-provider-route-ids compiled ordered-providers))
               {:status :exhausted
                :reason :missing-provider-route
                :model-id model-id

--- a/src/proxx/queue/runtime.cljs
+++ b/src/proxx/queue/runtime.cljs
@@ -79,7 +79,7 @@
       (reject (queue-wait-timeout-error))
       (resolve nil))))
 
-(defn- park-caller! [state-atom policy total-deadline]
+(defn- park-caller! [state-atom total-deadline]
   (swap! state-atom update :queued inc)
   (js/Promise.
    (fn [resolve reject]
@@ -87,11 +87,6 @@
             conj (make-waiter state-atom total-deadline resolve reject)))))
 
 ;; ── Acquire ───────────────────────────────────────────────────
-
-(defn- overflow-promise [policy active-count]
-  (if (= (:queue/overflow-policy policy) :reject)
-    (js/Promise.reject (queue-full-error policy active-count))
-    (js/Promise.reject (queue-dropped-error))))
 
 (defn ^:async acquire! [state-atom policy total-deadline]
   (let [{:keys [active queued]} @state-atom
@@ -107,7 +102,7 @@
                (queue-dropped-error)))
 
       :else
-      (await (park-caller! state-atom policy total-deadline)))))
+      (await (park-caller! state-atom total-deadline)))))
 
 ;; ── Per-attempt execution ─────────────────────────────────────
 


### PR DESCRIPTION
Unblocks staging -> main promotion by making CLJS lint pass: configures clj-kondo for the CLJS async await form and removes the newly reported unused bindings/var. Local verification: clj-kondo --lint src/proxx test/proxx; pnpm -s shadow-cljs compile runtime node-test.