### PR TITLE
fix: conditionally render coverageStart to avoid Never message

### DIFF
--- a/web/src/pages/DashboardPage.tsx
+++ b/web/src/pages/DashboardPage.tsx
@@ -346,7 +346,9 @@ export function DashboardPage(): JSX.Element {
 
       {overview?.coverage && !overview.coverage.hasFullWindowCoverage && (
         <span className="dashboard-coverage-note">
-          {windowLabel} window partially covered since {formatDate(overview.coverage.coverageStart)}.
+          {overview.coverage.coverageStart
+            ? `${windowLabel} window partially covered since ${formatDate(overview.coverage.coverageStart)}.`
+            : `${windowLabel} window partially covered.`}
         </span>
       )}
 


### PR DESCRIPTION
Closes #86

Agent-generated fix. Guards the coverage start display in DashboardPage.tsx so a null coverageStart no longer renders "Never".



## Test plan
- [ ] CI checks pass on staging
- [ ] Reviewer confirms the code change is correct