### PR TITLE
chore(deploy): migrate staging to proxx.promethean.rest with nginx passthrough

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -75,12 +75,12 @@ jobs:
           DEPLOY_USER: ${{ vars.STAGING_SSH_USER || 'error' }}
           DEPLOY_PATH: ${{ vars.STAGING_DEPLOY_PATH || '~/devel/services/proxx-staging' }}
           DEPLOY_COMPOSE_PROJECT_NAME: ${{ vars.STAGING_COMPOSE_PROJECT_NAME || 'proxx-staging' }}
-          DEPLOY_COMPOSE_FILES: docker-compose.federation-runtime.yml,deploy/docker-compose.federation.ssl.yml
-          DEPLOY_CADDY_TEMPLATE: deploy/Caddyfile.federation.template
-          DEPLOY_HEALTH_SERVICE: federation-nginx
-          DEPLOY_RESTART_SERVICES: federation-proxx-a1,federation-proxx-a2,federation-nginx,open-hax-openai-proxy-ssl
+          DEPLOY_COMPOSE_FILES: ${{ vars.STAGING_COMPOSE_FILES || 'docker-compose.federation-runtime.yml,deploy/docker-compose.federation.ssl.yml' }}
+          DEPLOY_CADDY_TEMPLATE: ${{ vars.STAGING_CADDY_TEMPLATE || 'deploy/Caddyfile.federation.template' }}
+          DEPLOY_HEALTH_SERVICE: ${{ vars.STAGING_HEALTH_SERVICE || 'federation-nginx' }}
+          DEPLOY_RESTART_SERVICES: ${{ vars.STAGING_RESTART_SERVICES || 'federation-proxx-a1,federation-proxx-a2,federation-nginx,open-hax-openai-proxy-ssl' }}
           DEPLOY_PUBLIC_HOST: ${{ vars.STAGING_PUBLIC_HOST || 'staging.proxx.ussy.promethean.rest' }}
-          DEPLOY_ENABLE_TLS: 'true'
+          DEPLOY_ENABLE_TLS: ${{ vars.STAGING_ENABLE_TLS || 'true' }}
           DEPLOY_HEALTH_TIMEOUT_SECONDS: '240'
           DEPLOY_SYNC_RUNTIME_FROM_SOURCE: 'true'
           DEPLOY_SYNC_DB_FROM_SOURCE: 'true'

--- a/deploy/docker-compose.federation.no-ssl.yml
+++ b/deploy/docker-compose.federation.no-ssl.yml
@@ -1,0 +1,4 @@
+services:
+  federation-nginx:
+    ports:
+      - "127.0.0.1:8890:80"


### PR DESCRIPTION
Moves the staging deploy target from ussy3.promethean.rest to proxx.promethean.rest, using the knoxx nginx for TLS instead of an embedded Caddy (avoids port 80/443 conflict).

## Changes
- `deploy/docker-compose.federation.no-ssl.yml` — new override that exposes \`federation-nginx\` on \`127.0.0.1:8890\` (knoxx nginx proxies HTTPS at \`staging-proxx.promethean.rest\` to this port)
- \`.github/workflows/deploy-staging.yml\` — parametrize 5 hardcoded env vars via \`vars.STAGING_*\` with existing defaults as fallback

## GitHub variables set
\`STAGING_SSH_HOST=proxx.promethean.rest\`, \`STAGING_PUBLIC_HOST=staging-proxx.promethean.rest\`, \`STAGING_COMPOSE_FILES=docker-compose.federation-runtime.yml,deploy/docker-compose.federation.no-ssl.yml\`, \`STAGING_ENABLE_TLS=false\`, \`STAGING_RESTART_SERVICES=federation-proxx-a1,federation-proxx-a2,federation-nginx\`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Made staging deployment configuration parameterizable via GitHub Actions variables, allowing flexible environment setup with secure defaults.
  * Added Docker Compose configuration for federation services with non-SSL deployment option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->