### PR TITLE
chore(deploy): parameterize DEPLOY_SYNC_RUNTIME/DB_FROM_SOURCE flags

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -82,8 +82,8 @@ jobs:
           DEPLOY_PUBLIC_HOST: ${{ vars.STAGING_PUBLIC_HOST || 'staging.proxx.ussy.promethean.rest' }}
           DEPLOY_ENABLE_TLS: ${{ vars.STAGING_ENABLE_TLS || 'true' }}
           DEPLOY_HEALTH_TIMEOUT_SECONDS: '240'
-          DEPLOY_SYNC_RUNTIME_FROM_SOURCE: 'true'
-          DEPLOY_SYNC_DB_FROM_SOURCE: 'true'
+          DEPLOY_SYNC_RUNTIME_FROM_SOURCE: ${{ vars.STAGING_SYNC_RUNTIME_FROM_SOURCE || 'true' }}
+          DEPLOY_SYNC_DB_FROM_SOURCE: ${{ vars.STAGING_SYNC_DB_FROM_SOURCE || 'true' }}
           DEPLOY_ENV_APPEND: |
             FEDERATION_CLUSTER_ID=staging
             FEDERATION_PUBLIC_HOST_SUFFIX=${{ vars.STAGING_PUBLIC_HOST || 'staging.proxx.ussy.promethean.rest' }}


### PR DESCRIPTION
Allows disabling source DB/runtime sync via STAGING_SYNC_DB_FROM_SOURCE and STAGING_SYNC_RUNTIME_FROM_SOURCE environment variables. Needed because the source proxx-local instance uses a different DB service name (proxx-local-db vs open-hax-openai-proxy-db).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated staging deployment configuration to allow database and runtime synchronization settings to be controlled via environment variables, enabling more flexible deployment behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->