### PR TITLE
fix(deploy): bind staging federation-nginx to 0.0.0.0:8890 for knoxx nginx proxy

### DIFF
--- a/deploy/docker-compose.federation.no-ssl.yml
+++ b/deploy/docker-compose.federation.no-ssl.yml
@@ -1,4 +1,4 @@
 services:
   federation-nginx:
     ports:
-      - "127.0.0.1:8890:80"
+      - "0.0.0.0:8890:80"


### PR DESCRIPTION
The knoxx nginx container routes HTTPS for staging-proxx.promethean.rest to host.docker.internal:8890. With the port bound to 127.0.0.1 only, the container cannot reach it. Bind to 0.0.0.0 instead.