### PR TITLE
chore: sync main into staging

### DIFF
--- a/.github/workflows/github-events-discord.yml
+++ b/.github/workflows/github-events-discord.yml
@@ -1,0 +1,148 @@
+name: GitHub Events to Discord
+
+on:
+  issues:
+    types: [opened, reopened, closed, labeled, unlabeled, assigned, unassigned]
+  issue_comment:
+    types: [created]
+  pull_request:
+    types: [opened, reopened, closed, ready_for_review, converted_to_draft, synchronize]
+  pull_request_review:
+    types: [submitted]
+  release:
+    types: [published]
+  push:
+    branches:
+      - main
+      - master
+      - dev
+      - "device/**"
+  workflow_run:
+    workflows:
+      - OpenCode Kimi PR Review
+      - OpenCode Kimi Issue Agent
+      - Code Review Comments to Discord
+    types: [completed]
+
+permissions:
+  contents: read
+  issues: read
+  pull-requests: read
+  actions: read
+
+jobs:
+  discord:
+    name: Send GitHub event to Discord
+    runs-on: ubuntu-latest
+    env:
+      HAS_DISCORD_REVIEW_WEBHOOK_URL: ${{ secrets.DISCORD_REVIEW_WEBHOOK_URL != '' }}
+    steps:
+      - name: Send GitHub event to Discord
+        if: ${{ env.HAS_DISCORD_REVIEW_WEBHOOK_URL == 'true' }}
+        uses: actions/github-script@v7
+        env:
+          DISCORD_REVIEW_WEBHOOK_URL: ${{ secrets.DISCORD_REVIEW_WEBHOOK_URL }}
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const webhookUrl = process.env.DISCORD_REVIEW_WEBHOOK_URL;
+            if (!webhookUrl) return;
+
+            const { owner, repo } = context.repo;
+            const eventName = context.eventName;
+            const action = context.payload.action;
+            const truncate = (value, max) => {
+              const text = String(value || '');
+              return text.length <= max ? text : `${text.slice(0, max - 1)}…`;
+            };
+            const field = (name, value, inline = true) => ({ name, value: truncate(value || 'n/a', 1024), inline });
+
+            let title = `${owner}/${repo}: ${eventName}${action ? `:${action}` : ''}`;
+            let url = `https://github.com/${owner}/${repo}`;
+            let description = '';
+            const fields = [field('Repository', `${owner}/${repo}`), field('Event', action ? `${eventName}:${action}` : eventName)];
+            let color = 0x64748b;
+
+            if (context.payload.issue) {
+              const issue = context.payload.issue;
+              const isPr = Boolean(issue.pull_request);
+              title = `${owner}/${repo} ${isPr ? 'PR' : 'issue'} #${issue.number}: ${issue.title}`;
+              url = issue.html_url;
+              description = truncate(issue.body || '', 1000);
+              fields.push(field('Author', issue.user?.login), field('State', issue.state));
+              color = issue.state === 'closed' ? 0x6b7280 : 0x22c55e;
+            }
+
+            if (context.payload.comment) {
+              const comment = context.payload.comment;
+              title = `${owner}/${repo}: comment by ${comment.user?.login || 'unknown'}`;
+              url = comment.html_url;
+              description = truncate(comment.body || '', 1500);
+              fields.push(field('Comment author', comment.user?.login));
+              color = 0x38bdf8;
+            }
+
+            if (context.payload.pull_request) {
+              const pr = context.payload.pull_request;
+              title = `${owner}/${repo} PR #${pr.number}: ${pr.title}`;
+              url = pr.html_url;
+              description = truncate(pr.body || '', 1000);
+              fields.push(field('Author', pr.user?.login), field('State', pr.merged ? 'merged' : pr.state), field('Head', pr.head?.ref), field('Base', pr.base?.ref));
+              color = pr.merged ? 0x8b5cf6 : pr.state === 'closed' ? 0x6b7280 : 0x22c55e;
+            }
+
+            if (context.payload.review) {
+              const review = context.payload.review;
+              fields.push(field('Review author', review.user?.login), field('Review state', review.state));
+              description = truncate(review.body || description, 1500);
+              url = review.html_url || url;
+              color = review.state === 'approved' ? 0x22c55e : review.state === 'changes_requested' ? 0xef4444 : 0xf59e0b;
+            }
+
+            if (context.payload.release) {
+              const release = context.payload.release;
+              title = `${owner}/${repo} release: ${release.name || release.tag_name}`;
+              url = release.html_url;
+              description = truncate(release.body || '', 1500);
+              fields.push(field('Tag', release.tag_name), field('Author', release.author?.login));
+              color = 0x8b5cf6;
+            }
+
+            if (eventName === 'push') {
+              const ref = context.payload.ref?.replace('refs/heads/', '') || 'unknown';
+              title = `${owner}/${repo}: push to ${ref}`;
+              url = context.payload.compare || url;
+              const commits = context.payload.commits || [];
+              description = commits.slice(0, 5).map((commit) => `- ${commit.id.slice(0, 7)} ${truncate(commit.message.split('\n')[0], 120)}`).join('\n');
+              fields.push(field('Pusher', context.payload.pusher?.name), field('Commits', String(commits.length)));
+              color = 0x0ea5e9;
+            }
+
+            if (eventName === 'workflow_run') {
+              const run = context.payload.workflow_run;
+              title = `${owner}/${repo}: workflow ${run.name} ${run.conclusion || run.status}`;
+              url = run.html_url;
+              description = truncate(run.display_title || '', 1000);
+              fields.push(field('Workflow', run.name), field('Status', run.conclusion || run.status), field('Branch', run.head_branch));
+              color = run.conclusion === 'success' ? 0x22c55e : run.conclusion === 'failure' ? 0xef4444 : 0xf59e0b;
+            }
+
+            const response = await fetch(webhookUrl, {
+              method: 'POST',
+              headers: { 'content-type': 'application/json' },
+              body: JSON.stringify({
+                username: 'GitHub Event Mirror',
+                embeds: [{
+                  title: truncate(title, 256),
+                  url,
+                  color,
+                  description: truncate(description, 3500),
+                  fields: fields.slice(0, 12),
+                  timestamp: new Date().toISOString(),
+                }],
+                allowed_mentions: { parse: [] },
+              }),
+            });
+            if (!response.ok) {
+              throw new Error(`Discord webhook failed: ${response.status} ${await response.text()}`);
+            }

--- a/.github/workflows/github-events-discord.yml
+++ b/.github/workflows/github-events-discord.yml
@@ -39,7 +39,7 @@ jobs:
     steps:
       - name: Send GitHub event to Discord
         if: ${{ env.HAS_DISCORD_REVIEW_WEBHOOK_URL == 'true' }}
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b
         env:
           DISCORD_REVIEW_WEBHOOK_URL: ${{ secrets.DISCORD_REVIEW_WEBHOOK_URL }}
         with:

--- a/.github/workflows/opencode-code-review.yml
+++ b/.github/workflows/opencode-code-review.yml
@@ -13,13 +13,13 @@ jobs:
     name: Review pull request with OpenCode
     if: ${{ github.event.pull_request.draft == false && github.event.pull_request.head.repo.full_name == github.repository }}
     runs-on: ubuntu-latest
+    env:
+      HAS_DISCORD_REVIEW_WEBHOOK_URL: ${{ secrets.DISCORD_REVIEW_WEBHOOK_URL != '' }}
     permissions:
       id-token: write
       contents: read
       pull-requests: write
       issues: write
-    env:
-      HAS_DISCORD_REVIEW_WEBHOOK_URL: ${{ secrets.DISCORD_REVIEW_WEBHOOK_URL != '' }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -41,7 +41,8 @@ jobs:
           prompt: |
             Review this pull request as a senior maintainer.
             Focus on correctness, security, maintainability, tests, and repo-specific conventions.
-            Prefer concise, actionable findings with enough context for the author to act.
+            Check linked GitHub issues and any synced Kanban markers (`openhax-kanban-sync`) to understand the task intent.
+            If this repository has a kanban/ directory or docs/agent-workflows.md, use it as planning context and keep status/priority labels in mind.
             Submit concrete findings as GitHub PR inline review comments on the exact changed lines whenever GitHub can attach them.
             If there are no actionable findings, leave a short passing review summary instead of inventing comments.
             Do not request cosmetic churn unless it prevents confusion or future defects.

--- a/.github/workflows/opencode-code-review.yml
+++ b/.github/workflows/opencode-code-review.yml
@@ -13,8 +13,6 @@ jobs:
     name: Review pull request with OpenCode
     if: ${{ github.event.pull_request.draft == false && github.event.pull_request.head.repo.full_name == github.repository }}
     runs-on: ubuntu-latest
-    env:
-      HAS_DISCORD_REVIEW_WEBHOOK_URL: ${{ secrets.DISCORD_REVIEW_WEBHOOK_URL != '' }}
     permissions:
       id-token: write
       contents: read

--- a/.github/workflows/opencode-issue-agent.yml
+++ b/.github/workflows/opencode-issue-agent.yml
@@ -38,6 +38,12 @@ jobs:
           prompt: |
             You are the Kimi issue agent for this repository. Triage the triggering GitHub issue.
 
+            Kanban context:
+            - Check whether the issue body contains an `openhax-kanban-sync` marker.
+            - If it does, treat the synced markdown Kanban card as task intent and preserve status/priority labels unless the issue clearly moved.
+            - If the repository has a kanban/ directory or docs/agent-workflows.md, use it to understand workflow vocabulary.
+            - Do not create duplicate issues for work already represented by a synced Kanban issue.
+
             Goals:
             - Decide whether the issue is actionable, duplicate, irrelevant, spam, or needs more information.
             - If the issue is clearly irrelevant, spam, out of scope, or a duplicate, leave a concise explanatory comment and close it.
@@ -76,6 +82,12 @@ jobs:
           use_github_token: true
           prompt: |
             Perform a daily maintenance sweep of this repository's open GitHub issues.
+
+            Kanban context:
+            - Prioritize issues with the `kanban` label or an `openhax-kanban-sync` marker.
+            - Use `status:*` and `priority:*` labels to understand current task state.
+            - Do not duplicate synced Kanban issues; update/comment on the existing issue instead.
+            - If a synced issue appears stale, recommend the next Kanban status transition rather than inventing a new workflow.
 
             Scope:
             - Use the GitHub API or gh CLI with GITHUB_TOKEN to inspect open issues, excluding pull requests.

--- a/docs/agent-workflows.md
+++ b/docs/agent-workflows.md
@@ -1,0 +1,101 @@
+# Agent Workflows: Kanban → GitHub → Kimi → Review Gates
+
+This repository participates in the shared OpenHax / Octave Commons automation stack. Agents working here should understand the following workflow before opening or reviewing PRs.
+
+## GitHub event visibility
+
+GitHub events are mirrored to Discord through `.github/workflows/github-events-discord.yml` using the `DISCORD_REVIEW_WEBHOOK_URL` secret.
+
+Mirrored events include:
+
+- issues and issue comments
+- pull request lifecycle events
+- pull request reviews
+- releases
+- pushes to `main`, `master`, `dev`, and `device/**`
+- selected workflow completions for OpenCode/Kimi review workflows
+
+Do not print or copy webhook URLs, bot tokens, GitHub tokens, Kimi keys, or other secrets into logs, issues, PR comments, or commits.
+
+## Kimi issue agent
+
+`.github/workflows/opencode-issue-agent.yml` runs OpenCode with Kimi For Coding on issue events and on a daily schedule.
+
+Kimi may:
+
+- triage new, reopened, or edited issues;
+- ask for clarification when an issue is underspecified;
+- close issues that are clearly irrelevant, spam, duplicates, or out of scope, with a concise reason;
+- open a linked PR for a small safe fix.
+
+Kimi must not close ambiguous issues or make broad/destructive changes.
+
+## Kimi PR code review
+
+`.github/workflows/opencode-code-review.yml` runs OpenCode with Kimi For Coding on pull requests.
+
+Kimi should:
+
+- review correctness, security, maintainability, tests, and repository conventions;
+- submit concrete findings as GitHub PR inline review comments on exact changed lines whenever GitHub can attach them;
+- leave a short passing summary when there are no actionable findings;
+- treat linked Kanban/GitHub issues as the source of task intent.
+
+Inline PR review comments are mirrored to Discord by `.github/workflows/code-review-comments-discord.yml`.
+
+## CodeRabbit and review gates
+
+CodeRabbit may add inline review comments. Repositories with branch protection enabled require review-thread resolution before merge when GitHub permits `required_conversation_resolution`.
+
+Agent rules:
+
+1. Do not merge while actionable inline review threads remain unresolved.
+2. Resolve CodeRabbit/Kimi comments by patching the code or explicitly explaining why no change is needed.
+3. Prefer small targeted commits over broad rewrites.
+4. Re-run or wait for required checks after pushing fixes.
+
+## Kanban → GitHub issue sync
+
+Markdown Kanban cards are the local planning source. GitHub issues are the collaboration and automation surface.
+
+The eta-mu CLI supports syncing Kanban cards to GitHub issues:
+
+```bash
+eta-mu kanban sync github --tasks-dir <kanban-dir> --repo <owner/repo> --dry-run
+eta-mu kanban sync github --tasks-dir <kanban-dir> --repo <owner/repo> --max-writes 25 --write-delay-ms 5000
+```
+
+The underlying package command is also available:
+
+```bash
+openhax-kanban sync github --tasks-dir <kanban-dir> --repo <owner/repo>
+```
+
+Sync behavior:
+
+- Issues are keyed by an idempotent marker: `<!-- openhax-kanban-sync uuid="..." -->`.
+- Labels include `kanban`, `status:<status>`, `priority:<priority>`, and task frontmatter labels.
+- Existing issues are updated when the Kanban title/body/status/labels change.
+- Existing issues are closed when the task becomes `done` or `rejected`.
+- New issues are not created for tasks already marked `done` or `rejected`.
+
+GitHub enforces secondary content-creation limits. Always dry-run first and use `--max-writes` plus `--write-delay-ms` for live syncs.
+
+## Kanban label vocabulary
+
+Typical labels produced by sync:
+
+- `kanban`
+- `status:icebox`, `status:incoming`, `status:accepted`, `status:breakdown`, `status:blocked`, `status:ready`, `status:todo`, `status:in_progress`, `status:review`, `status:document`, `status:done`, `status:rejected`
+- `priority:P0`, `priority:P1`, `priority:P2`, `priority:P3`
+- task-specific frontmatter labels, normalized for GitHub
+
+## Agent expectations
+
+When working on this repo:
+
+1. Look for local Kanban cards before creating new issues.
+2. If an issue has an `openhax-kanban-sync` marker, treat the synced Kanban card as the source of truth.
+3. Keep status labels consistent with actual task progress.
+4. Mention or link the synced issue/PR relationship when opening fixes.
+5. Preserve auditability: receipts, PR descriptions, and comments should explain what changed and why.


### PR DESCRIPTION
Brings staging up to date with the 2 commits that landed on main directly:

- `0dcc9cb` ci: mirror GitHub events to Discord
- `cd8162e` docs: document agent automation workflows

Required so PR #234 (staging → main) can satisfy the \"branch must be up to date\" rule.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Discord notifications for GitHub repository events (issues, pull requests, reviews, releases, and commits).

* **Improvements**
  * Enhanced code review workflow with improved context awareness for better decision-making.
  * Improved issue triage and automation with Kanban synchronization support.

* **Documentation**
  * Added comprehensive documentation on repository automation workflows and agent operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->