### PR TITLE
fix: address PR #234 review findings

### DIFF
--- a/docker-compose.federation-runtime.yml
+++ b/docker-compose.federation-runtime.yml
@@ -58,7 +58,7 @@ x-proxx-node: &proxx-node
     CHROMA_COLLECTION: "${CHROMA_COLLECTION:-open_hax_proxy_sessions}"
     CHROMA_EMBED_MODEL: "${CHROMA_EMBED_MODEL:-nomic-embed-text:latest}"
     FEDERATION_REQUEST_TIMEOUT_MS: "${FEDERATION_REQUEST_TIMEOUT_MS:-5000}"
-    FEDERATION_SELF_CLUSTER_ID: "${FEDERATION_CLUSTER_ID:-proxx-federation}"
+    FEDERATION_SELF_CLUSTER_ID: "${FEDERATION_SELF_CLUSTER_ID:-proxx-federation}"
     FEDERATION_DEFAULT_OWNER_SUBJECT: "${FEDERATION_DEFAULT_OWNER_SUBJECT:-}"
   restart: unless-stopped
   healthcheck:

--- a/src/lib/federation/bridge-routing.ts
+++ b/src/lib/federation/bridge-routing.ts
@@ -313,8 +313,8 @@ export const handleBridgeRequest = async (
     "/v1/embeddings",
     "/v1/images/generations",
   ];
-  const normalizedPath = input.path.split("?")[0]!;
-  if (!allowedBridgePaths.some((prefix) => normalizedPath.startsWith(prefix))) {
+  const normalizedPath = new URL(input.path.split("?")[0]!, "http://x").pathname;
+  if (!allowedBridgePaths.includes(normalizedPath)) {
     app.log.warn({ path: input.path, ownerSubject: input.ownerSubject }, "bridge request rejected: path not in allowed list");
     return {
       status: 403,

--- a/src/proxx/policy/contracts.cljs
+++ b/src/proxx/policy/contracts.cljs
@@ -861,8 +861,6 @@
                                            :base-url base-url}
                                    (contains? route :auth/required?)
                                    (assoc :auth-required? (:auth/required? route))
-                                   (contains? route :auth-required?)
-                                   (assoc :auth-required? (:auth-required? route))
                                    (contains? route :paths)
                                    (assoc :paths (:paths route)))]))))
         (:provider-routes compiled)))

--- a/src/routes/responses.ts
+++ b/src/routes/responses.ts
@@ -18,6 +18,7 @@ import {
   inspectProviderAvailability,
 } from "../lib/provider-strategy.js";
 import { resolveFederationOwnerSubject } from "../lib/federation/federation-helpers.js";
+import { executeBridgeRequestRouting } from "../lib/federation/bridge-routing.js";
 import {
   filterDeclaredProviderRoutes,
   filterResponsesApiRoutes,
@@ -355,6 +356,31 @@ export function registerResponsesRoutes(deps: AppDeps, app: FastifyInstance): vo
         }),
       );
       if (federatedResponsesHandled) {
+        return;
+      }
+
+      const bridgedResponsesHandled = await runCljsQueued(
+        deps.config.cljsPolicyManifestPath,
+        { "tenant-id": request.openHaxAuth?.tenantId ?? "default", "provider-id": providerRoutes[0]?.providerId, "request-kind": "responses" },
+        async () => await executeBridgeRequestRouting({
+          bridgeRelay: deps.bridgeRelay,
+          app: deps.app,
+          config: deps.config,
+          sqlTenantProviderPolicyStore: deps.sqlTenantProviderPolicyStore,
+          runtimeCredentialStore: deps.runtimeCredentialStore,
+          keyPool: deps.keyPool,
+        }, {
+          requestHeaders: request.headers,
+          requestBody,
+          requestAuth: request.openHaxAuth ?? undefined,
+          requestKind: "responses",
+          allowedProviderIds: providerRoutes.map((route) => route.providerId),
+          upstreamPath: "/v1/responses",
+          reply,
+          timeoutMs: executionContext.upstreamAttemptTimeoutMs,
+        }),
+      );
+      if (bridgedResponsesHandled) {
         return;
       }
 


### PR DESCRIPTION
Resolves the actionable findings from the OpenCode agent reviews on PR #234.

## Changes

- **`contracts.cljs`** — remove duplicate `:auth-required?` `cond->` branch (dead code, copy-paste error)
- **`docker-compose.federation-runtime.yml`** — fix `FEDERATION_SELF_CLUSTER_ID` to read from `FEDERATION_SELF_CLUSTER_ID` host env (was incorrectly reading `FEDERATION_CLUSTER_ID`, contradicting `.env.example`)
- **`bridge-routing.ts`** — normalize path with `new URL()` before allowlist check to prevent `../` traversal bypass; change `startsWith()` to `includes()` for exact-path matching
- **`responses.ts`** — add bridge routing after federated routing to match the pattern in `chat.ts`; `/v1/responses` was listed in `allowedBridgePaths` but the route handler never called `executeBridgeRequestRouting`

## Testing

The CLJS and TS changes require:
- `pnpm build:cljs` + `pnpm test:cljs`
- `pnpm build:ts` + `pnpm test`