### PR TITLE
fix: keep git credentials for OpenCode review action

### DIFF
--- a/.github/workflows/opencode-code-review.yml
+++ b/.github/workflows/opencode-code-review.yml
@@ -22,7 +22,6 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
-          persist-credentials: false
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Configure review git identity


### PR DESCRIPTION
Removes `persist-credentials: false` from the checkout step so the OpenCode review action can authenticate git operations against GitHub.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added federation service configuration enabling local deployment without SSL requirements

* **Chores**
  * Staging deployment configuration now accepts runtime variables for compose files, Caddy template, health checks, and service restarts
  * Made staging TLS configuration customizable via workflow variables
  * Updated workflow authentication mechanism

<!-- end of auto-generated comment: release notes by coderabbit.ai -->