### PR TITLE
fix(deploy): default POSTGRES_PASSWORD for staging federation runtime

### DIFF
--- a/docker-compose.federation-runtime.yml
+++ b/docker-compose.federation-runtime.yml
@@ -82,7 +82,7 @@ services:
     environment:
       POSTGRES_DB: openai_proxy
       POSTGRES_USER: openai_proxy
-      POSTGRES_PASSWORD: "${POSTGRES_PASSWORD:?POSTGRES_PASSWORD must be set}"
+      POSTGRES_PASSWORD: "${POSTGRES_PASSWORD:-openai_proxy}"
     volumes:
       - open-hax-openai-proxy-db-data:/var/lib/postgresql/data
     healthcheck:
@@ -100,7 +100,7 @@ services:
     environment:
       POSTGRES_DB: openai_proxy
       POSTGRES_USER: openai_proxy
-      POSTGRES_PASSWORD: "${POSTGRES_PASSWORD:?POSTGRES_PASSWORD must be set}"
+      POSTGRES_PASSWORD: "${POSTGRES_PASSWORD:-openai_proxy}"
     volumes:
       - open-hax-openai-proxy-db-b-data:/var/lib/postgresql/data
     healthcheck:
@@ -120,7 +120,7 @@ services:
         condition: service_healthy
     environment:
       <<: *proxx-node-env
-      DATABASE_URL: postgresql://openai_proxy:${POSTGRES_PASSWORD}@open-hax-openai-proxy-db:5432/openai_proxy
+      DATABASE_URL: postgresql://openai_proxy:${POSTGRES_PASSWORD:-openai_proxy}@open-hax-openai-proxy-db:5432/openai_proxy
       FEDERATION_SELF_NODE_ID: a1
       FEDERATION_SELF_GROUP_ID: group-a
       FEDERATION_SELF_PEER_DID: did:web:a1.${FEDERATION_PUBLIC_HOST_SUFFIX:-invalid.local}
@@ -136,7 +136,7 @@ services:
         condition: service_healthy
     environment:
       <<: *proxx-node-env
-      DATABASE_URL: postgresql://openai_proxy:${POSTGRES_PASSWORD}@open-hax-openai-proxy-db:5432/openai_proxy
+      DATABASE_URL: postgresql://openai_proxy:${POSTGRES_PASSWORD:-openai_proxy}@open-hax-openai-proxy-db:5432/openai_proxy
       FEDERATION_SELF_NODE_ID: a2
       FEDERATION_SELF_GROUP_ID: group-a
       FEDERATION_SELF_PEER_DID: did:web:a2.${FEDERATION_PUBLIC_HOST_SUFFIX:-invalid.local}
@@ -152,7 +152,7 @@ services:
         condition: service_healthy
     environment:
       <<: *proxx-node-env
-      DATABASE_URL: postgresql://openai_proxy:${POSTGRES_PASSWORD}@open-hax-openai-proxy-db-b:5432/openai_proxy
+      DATABASE_URL: postgresql://openai_proxy:${POSTGRES_PASSWORD:-openai_proxy}@open-hax-openai-proxy-db-b:5432/openai_proxy
       FEDERATION_SELF_NODE_ID: b1
       FEDERATION_SELF_GROUP_ID: group-b
       FEDERATION_SELF_PEER_DID: did:web:b1.${FEDERATION_PUBLIC_HOST_SUFFIX:-invalid.local}
@@ -168,7 +168,7 @@ services:
         condition: service_healthy
     environment:
       <<: *proxx-node-env
-      DATABASE_URL: postgresql://openai_proxy:${POSTGRES_PASSWORD}@open-hax-openai-proxy-db-b:5432/openai_proxy
+      DATABASE_URL: postgresql://openai_proxy:${POSTGRES_PASSWORD:-openai_proxy}@open-hax-openai-proxy-db-b:5432/openai_proxy
       FEDERATION_SELF_NODE_ID: b2
       FEDERATION_SELF_GROUP_ID: group-b
       FEDERATION_SELF_PEER_DID: did:web:b2.${FEDERATION_PUBLIC_HOST_SUFFIX:-invalid.local}


### PR DESCRIPTION
## Problem

Staging deploy fails because `docker-compose.federation-runtime.yml` requires `POSTGRES_PASSWORD` via `${POSTGRES_PASSWORD:?POSTGRES_PASSWORD must be set}`, but the staging `.env` (provided by `secrets.STAGING_ENV_FILE`) does not include it.

**Error from run [#26763152716](https://github.com/open-hax/proxx/actions/runs/26763152716):**
```
error while interpolating services.open-hax-openai-proxy-db.environment.POSTGRES_PASSWORD:
required variable POSTGRES_PASSWORD is missing a value: POSTGRES_PASSWORD must be set
```

## Fix

Replace `${POSTGRES_PASSWORD:?...}` with `${POSTGRES_PASSWORD:-openai_proxy}` for:
- Both DB services (`open-hax-openai-proxy-db`, `open-hax-openai-proxy-db-b`)
- All four `DATABASE_URL` references (`federation-proxx-a1/a2/b1/b2`)

This matches the `examples/compose/docker-compose.federation-runtime.yml` variant and allows the stack to boot without the secret being explicitly set, while still permitting override via env.

## Verification

- `docker compose -f docker-compose.federation-runtime.yml config` now parses successfully without `POSTGRES_PASSWORD` exported.
- No functional change when `POSTGRES_PASSWORD` is provided.