### PR TITLE
fix(deploy): validate required env vars before remote compose up

### DIFF
--- a/scripts/deploy-remote.sh
+++ b/scripts/deploy-remote.sh
@@ -450,6 +450,14 @@ EOF
 }
 
 build_runtime_payloads
+if [[ -f "$TMP_DIR/.env" ]]; then
+  validate_required_env_vars "$TMP_DIR/.env"
+else
+  remote_env="$TMP_DIR/remote.env"
+  if fetch_remote_file_if_exists "$REMOTE" "$DEPLOY_PATH/.env" "$remote_env"; then
+    validate_required_env_vars "$remote_env"
+  fi
+fi
 sync_repo_tree
 if [[ -f "$TMP_DIR/.env" ]]; then
   validate_required_env_vars "$TMP_DIR/.env"


### PR DESCRIPTION
Adds validate_required_env_vars() to deploy-remote.sh which checks that PROXY_AUTH_TOKEN and POSTGRES_PASSWORD are present and non-empty (trimmed) in the .env file before attempting docker compose up.

Also validates the remote .env when no local payload is produced, preventing stale remote .env files from triggering late failures.

Validation runs before sync_repo_tree so missing variables fail fast without the cost and side effects of a full rsync.

This catches missing required variables early with a clear error message instead of failing late with cryptic compose interpolation errors like:

  required variable POSTGRES_PASSWORD is missing a value

Refs: open-hax/proxx#238