### PR TITLE
Fix staging federation nginx node routing

### DIFF
--- a/deploy/nginx.federation.runtime.conf
+++ b/deploy/nginx.federation.runtime.conf
@@ -5,6 +5,8 @@ events {
 }
 
 http {
+  resolver 127.0.0.11 valid=30s ipv6=off;
+
   map $http_upgrade $connection_upgrade {
     default upgrade;
     '' close;
@@ -56,24 +58,29 @@ http {
 
   # Route by normalized host instead of $http_host so node-specific
   # federation hosts still match when clients/proxies include a port.
+  #
+  # Keep variable proxy_pass targets as concrete Docker DNS names. Nginx can
+  # select static upstream groups with proxy_pass, but upstream-group names
+  # stored in variables are not reliable across reloads in the containerized
+  # resolver path.
   map $host $federation_api_upstream {
-    default federation_cluster_api;
-    ~^group-a\. federation_group_a_api;
-    ~^group-b\. federation_group_b_api;
-    ~^a1\. federation_node_a1_api;
-    ~^a2\. federation_node_a2_api;
-    ~^b1\. federation_node_b1_api;
-    ~^b2\. federation_node_b2_api;
+    default federation-proxx-a1:8789;
+    ~^group-a\. federation-proxx-a1:8789;
+    ~^group-b\. federation-proxx-b1:8789;
+    ~^a1\. federation-proxx-a1:8789;
+    ~^a2\. federation-proxx-a2:8789;
+    ~^b1\. federation-proxx-b1:8789;
+    ~^b2\. federation-proxx-b2:8789;
   }
 
   map $host $federation_web_upstream {
-    default federation_cluster_web;
-    ~^group-a\. federation_group_a_web;
-    ~^group-b\. federation_group_b_web;
-    ~^a1\. federation_node_a1_web;
-    ~^a2\. federation_node_a2_web;
-    ~^b1\. federation_node_b1_web;
-    ~^b2\. federation_node_b2_web;
+    default federation-proxx-a1:5174;
+    ~^group-a\. federation-proxx-a1:5174;
+    ~^group-b\. federation-proxx-b1:5174;
+    ~^a1\. federation-proxx-a1:5174;
+    ~^a2\. federation-proxx-a2:5174;
+    ~^b1\. federation-proxx-b1:5174;
+    ~^b2\. federation-proxx-b2:5174;
   }
 
   server {


### PR DESCRIPTION
## Summary
- make federation nginx variable proxy targets concrete Docker DNS names
- add Docker resolver for runtime service-name resolution

## Validation
- tested live staging nginx config with nginx -t
- verified a1/a2/b1/b2 hosts route to matching node IDs on proxx.promethean.rest

Supports deploy recovery for #238.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced federation routing configuration with improved DNS resolution and upstream target selection to optimize request distribution across federation services.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->