### PR TITLE
Handle responses stream cancel rejections

### DIFF
--- a/src/lib/provider-strategy/strategies/responses-event-stream.ts
+++ b/src/lib/provider-strategy/strategies/responses-event-stream.ts
@@ -42,7 +42,7 @@ export async function handleResponsesEventStreamAsChatCompletion(
       }
     } catch (err) {
       console.error("[responses-event-stream] stream read error", { providerId: context.providerId, message: err instanceof Error ? err.message : String(err) });
-      void upstreamResponse.body?.cancel();
+      void upstreamResponse.body?.cancel().catch(() => undefined);
     }
     if (!rawResponse.writableEnded) {
       rawResponse.end();


### PR DESCRIPTION
## Summary
- attach a rejection handler to upstream response body cancellation after stream read errors

## Validation
- pnpm install --frozen-lockfile
- pnpm exec eslint src/lib/provider-strategy/strategies/responses-event-stream.ts --quiet
- pnpm run typecheck
- git diff --check

Addresses the actionable review finding on PR #238.