### PR TITLE
Parameterize production deploy for proxx host

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -78,29 +78,32 @@ jobs:
           DEPLOY_USER: ${{ vars.PRODUCTION_SSH_USER || 'error' }}
           DEPLOY_PATH: ${{ vars.PRODUCTION_DEPLOY_PATH || '~/devel/services/proxx' }}
           DEPLOY_COMPOSE_PROJECT_NAME: ${{ vars.PRODUCTION_COMPOSE_PROJECT_NAME || 'open-hax-openai-proxy' }}
-          DEPLOY_COMPOSE_FILES: docker-compose.federation-runtime.yml,deploy/docker-compose.federation.ssl.yml
-          DEPLOY_CADDY_TEMPLATE: deploy/Caddyfile.federation.template
-          DEPLOY_HEALTH_SERVICE: federation-nginx
-          DEPLOY_RESTART_SERVICES: federation-proxx-a1,federation-proxx-a2,federation-nginx,open-hax-openai-proxy-ssl
+          DEPLOY_COMPOSE_FILES: ${{ vars.PRODUCTION_COMPOSE_FILES || 'docker-compose.federation-runtime.yml,deploy/docker-compose.federation.ssl.yml' }}
+          DEPLOY_CADDY_TEMPLATE: ${{ vars.PRODUCTION_CADDY_TEMPLATE || 'deploy/Caddyfile.federation.template' }}
+          DEPLOY_HEALTH_SERVICE: ${{ vars.PRODUCTION_HEALTH_SERVICE || 'federation-nginx' }}
+          DEPLOY_RESTART_SERVICES: ${{ vars.PRODUCTION_RESTART_SERVICES || 'federation-proxx-a1,federation-proxx-a2,federation-nginx,open-hax-openai-proxy-ssl' }}
           DEPLOY_PUBLIC_HOST: ${{ vars.PRODUCTION_PUBLIC_HOST || 'prod.proxx.ussy.promethean.rest' }}
-          DEPLOY_ENABLE_TLS: 'true'
+          DEPLOY_ENABLE_TLS: ${{ vars.PRODUCTION_ENABLE_TLS || 'true' }}
           DEPLOY_HEALTH_TIMEOUT_SECONDS: '240'
           DEPLOY_ENV_APPEND: |
             FEDERATION_CLUSTER_ID=prod
             FEDERATION_PUBLIC_HOST_SUFFIX=${{ vars.PRODUCTION_PUBLIC_HOST || 'prod.proxx.ussy.promethean.rest' }}
             FEDERATION_DEFAULT_OWNER_SUBJECT=did:web:${{ vars.PRODUCTION_PUBLIC_HOST || 'prod.proxx.ussy.promethean.rest' }}
+            FEDERATION_NGINX_PUBLISHED_PORT=${{ vars.PRODUCTION_NGINX_PUBLISHED_PORT || '8890' }}
           DEPLOY_ENV_FILE: ${{ secrets.PRODUCTION_ENV_FILE }}
           DEPLOY_MODELS_JSON: ${{ secrets.PRODUCTION_MODELS_JSON }}
       - name: production deploy failure logs
         if: failure()
         run: |
+          compose_args=$(echo "${DEPLOY_COMPOSE_FILES}" | tr ',' '\n' | awk '{printf " -f %s", $0}')
           # shellcheck disable=SC2029,SC2086
-          ssh ${PRODUCTION_SSH_USER}@${PRODUCTION_HOST} "cd ${PRODUCTION_PATH} && docker compose --project-name '${PRODUCTION_PROJECT}' -f docker-compose.federation-runtime.yml -f deploy/docker-compose.federation.ssl.yml ps && docker compose --project-name '${PRODUCTION_PROJECT}' -f docker-compose.federation-runtime.yml -f deploy/docker-compose.federation.ssl.yml logs --tail=200"
+          ssh ${PRODUCTION_SSH_USER}@${PRODUCTION_HOST} "cd ${PRODUCTION_PATH} && docker compose --project-name '${PRODUCTION_PROJECT}'${compose_args} ps && docker compose --project-name '${PRODUCTION_PROJECT}'${compose_args} logs --tail=200"
         env:
           PRODUCTION_HOST: ${{ vars.PRODUCTION_SSH_HOST || 'ussy.promethean.rest' }}
           PRODUCTION_SSH_USER: ${{ vars.PRODUCTION_SSH_USER || 'error' }}
           PRODUCTION_PATH: ${{ vars.PRODUCTION_DEPLOY_PATH || '~/devel/services/proxx' }}
           PRODUCTION_PROJECT: ${{ vars.PRODUCTION_COMPOSE_PROJECT_NAME || 'open-hax-openai-proxy' }}
+          DEPLOY_COMPOSE_FILES: ${{ vars.PRODUCTION_COMPOSE_FILES || 'docker-compose.federation-runtime.yml,deploy/docker-compose.federation.ssl.yml' }}
 
   verify-production:
     name: verify-production

--- a/deploy/docker-compose.federation.no-ssl.yml
+++ b/deploy/docker-compose.federation.no-ssl.yml
@@ -1,4 +1,4 @@
 services:
   federation-nginx:
     ports:
-      - "0.0.0.0:8890:80"
+      - "0.0.0.0:${FEDERATION_NGINX_PUBLISHED_PORT:-8890}:80"


### PR DESCRIPTION
## Summary
- let production deploy use environment-configured compose files/TLS/restart settings
- make production failure logs respect configured compose files
- make no-ssl federation nginx published port configurable

## Validation
- python YAML parse for deploy-production workflow
- git diff --check

Operational setup performed separately on `error@proxx.promethean.rest`: production env vars/secrets pointed at `~/devel/services/proxx-production`, `proxx.promethean.rest`, and port `8891`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
* Production deployment workflow now supports configurable deployment parameters via environment variables, including compose files and health service settings.
* Federation service nginx port is now parameterizable through environment variables, with a default value of 8890.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->