### PR TITLE
Promote production runtime data deploy fix

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -90,6 +90,13 @@ jobs:
             FEDERATION_PUBLIC_HOST_SUFFIX=${{ vars.PRODUCTION_PUBLIC_HOST || 'prod.proxx.ussy.promethean.rest' }}
             FEDERATION_DEFAULT_OWNER_SUBJECT=did:web:${{ vars.PRODUCTION_PUBLIC_HOST || 'prod.proxx.ussy.promethean.rest' }}
             FEDERATION_NGINX_PUBLISHED_PORT=${{ vars.PRODUCTION_NGINX_PUBLISHED_PORT || '8890' }}
+            PROXX_CONTAINER_UID=${{ vars.PRODUCTION_CONTAINER_UID || '1000' }}
+            PROXX_CONTAINER_GID=${{ vars.PRODUCTION_CONTAINER_GID || '1000' }}
+            PROXX_RUNTIME_DATA_DIR=${{ vars.PRODUCTION_RUNTIME_DATA_DIR || './data' }}
+            PROXX_CONTAINER_HOME=${{ vars.PRODUCTION_CONTAINER_HOME || '/home/node' }}
+            PM2_HOME=${{ vars.PRODUCTION_PM2_HOME || '/home/node/.pm2' }}
+            COREPACK_HOME=${{ vars.PRODUCTION_COREPACK_HOME || '/home/node/.cache/node/corepack' }}
+            XDG_CACHE_HOME=${{ vars.PRODUCTION_XDG_CACHE_HOME || '/home/node/.cache' }}
           DEPLOY_ENV_FILE: ${{ secrets.PRODUCTION_ENV_FILE }}
           DEPLOY_MODELS_JSON: ${{ secrets.PRODUCTION_MODELS_JSON }}
       - name: production deploy failure logs

--- a/deploy/nginx.federation.runtime.conf
+++ b/deploy/nginx.federation.runtime.conf
@@ -94,6 +94,7 @@ http {
       proxy_set_header X-Forwarded-Host $host;
       proxy_set_header X-Forwarded-Proto $scheme;
       proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+      proxy_set_header Authorization $http_authorization;
       proxy_set_header Upgrade $http_upgrade;
       proxy_set_header Connection $connection_upgrade;
       proxy_connect_timeout 30s;
@@ -108,6 +109,7 @@ http {
       proxy_set_header X-Forwarded-Host $host;
       proxy_set_header X-Forwarded-Proto $scheme;
       proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+      proxy_set_header Authorization $http_authorization;
       proxy_set_header Connection "";
     }
   }

--- a/docker-compose.federation-runtime.yml
+++ b/docker-compose.federation-runtime.yml
@@ -4,12 +4,17 @@ x-proxx-node: &proxx-node
   build:
     context: .
     dockerfile: Dockerfile
+  user: "${PROXX_CONTAINER_UID:-1000}:${PROXX_CONTAINER_GID:-1000}"
   environment: &proxx-node-env
     NODE_ENV: production
     PROXY_HOST: 0.0.0.0
     PROXY_PORT: "8789"
     PORT: "8789"
     PROXX_CLJS_POLICY_AUTHORITATIVE: "true"
+    HOME: "${PROXX_CONTAINER_HOME:-/home/node}"
+    PM2_HOME: "${PM2_HOME:-/home/node/.pm2}"
+    COREPACK_HOME: "${COREPACK_HOME:-/home/node/.cache/node/corepack}"
+    XDG_CACHE_HOME: "${XDG_CACHE_HOME:-/home/node/.cache}"
     PROXY_AUTH_TOKEN: "${PROXY_AUTH_TOKEN:?PROXY_AUTH_TOKEN must be set}"
     PROXY_MODELS_FILE: /workspace/service-config/models.json
     PROXY_REQUEST_LOGS_FILE: /app/data/request-logs.jsonl
@@ -58,6 +63,7 @@ x-proxx-node: &proxx-node
     CHROMA_COLLECTION: "${CHROMA_COLLECTION:-open_hax_proxy_sessions}"
     CHROMA_EMBED_MODEL: "${CHROMA_EMBED_MODEL:-nomic-embed-text:latest}"
     FEDERATION_REQUEST_TIMEOUT_MS: "${FEDERATION_REQUEST_TIMEOUT_MS:-5000}"
+    VITE_ALLOWED_HOSTS: "${VITE_ALLOWED_HOSTS:-}"
     FEDERATION_SELF_CLUSTER_ID: "${FEDERATION_SELF_CLUSTER_ID:-proxx-federation}"
     FEDERATION_DEFAULT_OWNER_SUBJECT: "${FEDERATION_DEFAULT_OWNER_SUBJECT:-}"
   restart: unless-stopped
@@ -127,7 +133,7 @@ services:
       FEDERATION_SELF_PUBLIC_BASE_URL: "${FEDERATION_SCHEME:-https}://a1.${FEDERATION_PUBLIC_HOST_SUFFIX:-invalid.local}"
     volumes:
       - ./models.json:/workspace/service-config/models.json:ro
-      - ./data/federation/a1:/app/data
+      - ${PROXX_RUNTIME_DATA_DIR:-./data}/federation/a1:/app/data
 
   federation-proxx-a2:
     <<: *proxx-node
@@ -143,7 +149,7 @@ services:
       FEDERATION_SELF_PUBLIC_BASE_URL: "${FEDERATION_SCHEME:-https}://a2.${FEDERATION_PUBLIC_HOST_SUFFIX:-invalid.local}"
     volumes:
       - ./models.json:/workspace/service-config/models.json:ro
-      - ./data/federation/a2:/app/data
+      - ${PROXX_RUNTIME_DATA_DIR:-./data}/federation/a2:/app/data
 
   federation-proxx-b1:
     <<: *proxx-node
@@ -159,7 +165,7 @@ services:
       FEDERATION_SELF_PUBLIC_BASE_URL: "${FEDERATION_SCHEME:-https}://b1.${FEDERATION_PUBLIC_HOST_SUFFIX:-invalid.local}"
     volumes:
       - ./models.json:/workspace/service-config/models.json:ro
-      - ./data/federation/b1:/app/data
+      - ${PROXX_RUNTIME_DATA_DIR:-./data}/federation/b1:/app/data
 
   federation-proxx-b2:
     <<: *proxx-node
@@ -175,7 +181,7 @@ services:
       FEDERATION_SELF_PUBLIC_BASE_URL: "${FEDERATION_SCHEME:-https}://b2.${FEDERATION_PUBLIC_HOST_SUFFIX:-invalid.local}"
     volumes:
       - ./models.json:/workspace/service-config/models.json:ro
-      - ./data/federation/b2:/app/data
+      - ${PROXX_RUNTIME_DATA_DIR:-./data}/federation/b2:/app/data
 
   federation-nginx:
     image: nginx:1.27-alpine

--- a/scripts/deploy-remote.sh
+++ b/scripts/deploy-remote.sh
@@ -134,6 +134,12 @@ sync_repo_tree() {
   ssh "${SSH_OPTS[@]}" "$REMOTE" bash -s -- "$DEPLOY_PATH" "$DEPLOY_PATH/data" "$DEPLOY_PATH/db-backups" "$DEPLOY_PATH/deploy" <<'EOF'
 set -euo pipefail
 mkdir -p "$1" "$2" "$3" "$4"
+mkdir -p "$2/federation/a1" "$2/federation/a2" "$2/federation/b1" "$2/federation/b2"
+mkdir -p "$1/runtime-data/federation/a1" "$1/runtime-data/federation/a2" "$1/runtime-data/federation/b1" "$1/runtime-data/federation/b2"
+mkdir -p "$1/runtime-data-v2/federation/a1" "$1/runtime-data-v2/federation/a2" "$1/runtime-data-v2/federation/b1" "$1/runtime-data-v2/federation/b2"
+mkdir -p "$1/runtime-data-v3/federation/a1" "$1/runtime-data-v3/federation/a2" "$1/runtime-data-v3/federation/b1" "$1/runtime-data-v3/federation/b2"
+chmod -R g+rwX "$2" "$1/runtime-data" "$1/runtime-data-v2" 2>/dev/null || true
+chmod -R a+rwX "$1/runtime-data-v3" 2>/dev/null || true
 EOF
 
   rsync -az --delete \
@@ -144,6 +150,9 @@ EOF
     --exclude '/.env' \
     --exclude '/models.json' \
     --exclude '/data/' \
+    --exclude '/runtime-data/' \
+    --exclude '/runtime-data-v2/' \
+    --exclude '/runtime-data-v3/' \
     --exclude '/db-backups/' \
     "$ROOT_DIR/" "$REMOTE:$DEPLOY_PATH/"
 


### PR DESCRIPTION
## Summary
- promote the production runtime data/container env fix from staging to main
- needed so the production deploy workflow matches the manually repaired proxx.promethean.rest runtime

## Validation
- PR #251 checks passed on staging
- manual production deploy is healthy on error@proxx.promethean.rest:8891
- https://proxx.promethean.rest/health and / return 200 after nginx cutover