### PR TITLE
Forward authorization through federation nginx

### DIFF
--- a/deploy/nginx.federation.runtime.conf
+++ b/deploy/nginx.federation.runtime.conf
@@ -94,6 +94,7 @@ http {
       proxy_set_header X-Forwarded-Host $host;
       proxy_set_header X-Forwarded-Proto $scheme;
       proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+      proxy_set_header Authorization $http_authorization;
       proxy_set_header Upgrade $http_upgrade;
       proxy_set_header Connection $connection_upgrade;
       proxy_connect_timeout 30s;
@@ -108,6 +109,7 @@ http {
       proxy_set_header X-Forwarded-Host $host;
       proxy_set_header X-Forwarded-Proto $scheme;
       proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+      proxy_set_header Authorization $http_authorization;
       proxy_set_header Connection "";
     }
   }


### PR DESCRIPTION
## Summary
- explicitly forward Authorization through federation nginx API and web proxy locations
- preserves bearer auth after the no-SSL outer-nginx deployment path routes through federation nginx

## Validation
- git diff --check
- hot-patched staging federation nginx and verified authenticated /v1/models returns 200 through :8890
- synchronized STAGING_PROXY_AUTH_TOKEN with the live staging PROXY_AUTH_TOKEN without printing it

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated federation service configuration to properly forward authorization headers to upstream API and backend services.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->