### PR TITLE
Promote bridge lease health fixes to production

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -771,10 +771,6 @@ export async function createApp(config: ProxyConfig): Promise<FastifyInstance> {
     }
   });
 
-  if (bridgeAgent) {
-    await bridgeAgent.start();
-  }
-
   app.addHook("onClose", async () => {
     if (bridgeAgent) {
       await bridgeAgent.stop();
@@ -834,6 +830,10 @@ export async function createApp(config: ProxyConfig): Promise<FastifyInstance> {
 
     reply.code(404).send({ ok: false, error: "Not Found" });
   });
+
+  if (bridgeAgent) {
+    await bridgeAgent.start();
+  }
 
   return app;
 }

--- a/src/lib/federation/bridge-agent-autostart.ts
+++ b/src/lib/federation/bridge-agent-autostart.ts
@@ -252,14 +252,19 @@ async function buildCapabilities(
   const topologyTargets = groupId && nodeId ? [{ groupId, nodeId }] : [];
   const resolvedModelCatalog = getResolvedModelCatalog ? await getResolvedModelCatalog().catch(() => ({ modelIds: [] })) : { modelIds: [] };
 
-  return providers.map((provider) => {
+  return providers.flatMap((provider) => {
     const providerStatus = statuses[provider.id];
+    const availableAccountCount = providerStatus?.availableAccounts ?? provider.accountCount;
+    if (availableAccountCount <= 0) {
+      return [];
+    }
+
     const modelPrefixes = capabilityPrefixesForProvider(provider.id, config);
     const paths = capabilityPathsForProvider(config);
     const models = modelPrefixes.length > 0
       ? resolvedModelCatalog.modelIds.filter((modelId) => modelPrefixes.some((prefix) => modelId.startsWith(prefix.replace(/[:/]$/u, ""))))
       : [];
-    return {
+    return [{
       providerId: provider.id,
       modelPrefixes,
       models,
@@ -267,17 +272,17 @@ async function buildCapabilities(
       routes: paths,
       authType: provider.authType,
       accountCount: provider.accountCount,
-      availableAccountCount: providerStatus?.availableAccounts ?? provider.accountCount,
+      availableAccountCount,
       supportsModelsList: true,
       supportsChatCompletions: true,
       supportsResponses: true,
       supportsStreaming: true,
-      supportsWarmImport: false,
+      supportsWarmImport: provider.authType === "oauth_bearer",
       credentialMobility: provider.authType === "oauth_bearer" ? "access_token_only" : "importable",
       credentialOrigin: provider.authType === "oauth_bearer" ? "localhost_oauth" : "local_api_key",
-      lastHealthyAt: provider.accountCount > 0 ? new Date().toISOString() : undefined,
+      lastHealthyAt: new Date().toISOString(),
       topologyTargets,
-    };
+    }];
   });
 }
 
@@ -290,11 +295,16 @@ async function buildHealth(keyPool: KeyPool, credentialStore: CredentialStoreLik
   const groupId = process.env.FEDERATION_SELF_GROUP_ID?.trim();
   const nodeId = process.env.FEDERATION_SELF_NODE_ID?.trim();
   const availableAccountCount = Object.values(statuses).reduce((sum, status) => sum + status.availableAccounts, 0);
-  const localOauthBootstrapReady = providers.some((provider) => provider.authType === "oauth_bearer" && provider.accountCount > 0);
+  const localOauthBootstrapReady = providers.some((provider) => {
+    if (provider.authType !== "oauth_bearer") {
+      return false;
+    }
+    return (statuses[provider.id]?.availableAccounts ?? 0) > 0;
+  });
 
   return {
     processHealthy: true,
-    upstreamHealthy: availableAccountCount > 0 || providers.length > 0,
+    upstreamHealthy: availableAccountCount > 0,
     availableAccountCount,
     localOauthBootstrapReady,
     queuedRequests: 0,

--- a/src/lib/federation/bridge-routing.ts
+++ b/src/lib/federation/bridge-routing.ts
@@ -156,10 +156,13 @@ export async function executeBridgeRequestRouting(
     .filter((session) => session.state === "connected")
     .filter((session) => session.ownerSubject === ownerSubject)
     .filter((session) => session.tenantId === tenantId)
+    .filter((session) => session.health === undefined
+      || (session.health.upstreamHealthy === true && session.health.availableAccountCount > 0))
     .map(async (session) => {
       for (const capability of session.capabilities) {
         const capabilityProviderId = capability.providerId.trim().toLowerCase();
         if ((allowedProviderIds.size > 0 && !allowedProviderIds.has(capabilityProviderId))
+          || capability.availableAccountCount <= 0
           || !bridgeCapabilitySupportsPath(capability, normalizedPath)
           || !bridgeCapabilitySupportsModel(capability, requestedModel)) {
           continue;
@@ -312,6 +315,9 @@ export const handleBridgeRequest = async (
     "/v1/responses",
     "/v1/embeddings",
     "/v1/images/generations",
+    "/api/bridge/credentials/accounts",
+    "/api/bridge/credentials/providers",
+    "/api/bridge/credentials/export",
   ];
   const normalizedPath = new URL(input.path.split("?")[0]!, "http://x").pathname;
   if (!allowedBridgePaths.includes(normalizedPath)) {

--- a/src/lib/key-pool.ts
+++ b/src/lib/key-pool.ts
@@ -1167,7 +1167,7 @@ export class KeyPool {
         const disabled = this.disabledAccountKeys.has(key);
         const expired = typeof credential.expiresAt === "number" && credential.expiresAt <= now + expiryBuffer;
         const inFlight = (this.inFlightByAccountKey.get(key) ?? 0) > 0;
-        const available = !disabled && !expired && (cooldownUntil ?? 0) <= now;
+        const available = (cooldownUntil ?? 0) <= now;
         return {
           providerId,
           accountId: credential.accountId,

--- a/src/lib/key-pool.ts
+++ b/src/lib/key-pool.ts
@@ -50,6 +50,7 @@ export interface KeyPoolStatus {
   readonly availableAccounts: number;
   readonly cooldownAccounts: number;
   readonly disabledAccounts: number;
+  readonly expiredAccounts: number;
   readonly inFlightAccounts: number;
   readonly nextReadyInMs: number;
 }
@@ -59,8 +60,11 @@ export interface KeyPoolAccountStatus {
   readonly accountId: string;
   readonly authType: ProviderAuthType;
   readonly available: boolean;
+  readonly disabled: boolean;
+  readonly expired: boolean;
   readonly inFlight: boolean;
   readonly cooldownUntil?: number;
+  readonly expiresAt?: number;
   readonly nextReadyInMs: number;
 }
 
@@ -1077,6 +1081,7 @@ export class KeyPool {
         availableAccounts: 0,
         cooldownAccounts: 0,
         disabledAccounts: 0,
+        expiredAccounts: 0,
         inFlightAccounts: 0,
         nextReadyInMs: 0
       };
@@ -1086,17 +1091,26 @@ export class KeyPool {
     let availableAccounts = 0;
     let cooldownAccounts = 0;
     let disabledAccounts = 0;
+    let expiredAccounts = 0;
     let inFlightAccounts = 0;
     let minDelay = Number.POSITIVE_INFINITY;
+    const expiryBuffer = resolveExpiryBufferMs(this.config.expiryBufferMs);
 
     for (const credential of providerState.accounts) {
-      if (this.disabledAccountKeys.has(accountStateKey(credential))) {
+      const key = accountStateKey(credential);
+      if (this.disabledAccountKeys.has(key)) {
         disabledAccounts += 1;
         continue;
       }
 
-      const cooldownUntil = this.cooldownByAccountKey.get(accountStateKey(credential)) ?? 0;
-      if ((this.inFlightByAccountKey.get(accountStateKey(credential)) ?? 0) > 0) {
+      const isExpired = typeof credential.expiresAt === "number" && credential.expiresAt <= now + expiryBuffer;
+      if (isExpired) {
+        expiredAccounts += 1;
+        continue;
+      }
+
+      const cooldownUntil = this.cooldownByAccountKey.get(key) ?? 0;
+      if ((this.inFlightByAccountKey.get(key) ?? 0) > 0) {
         inFlightAccounts += 1;
       }
       if (cooldownUntil <= now) {
@@ -1122,6 +1136,7 @@ export class KeyPool {
       availableAccounts,
       cooldownAccounts,
       disabledAccounts,
+      expiredAccounts,
       inFlightAccounts,
       nextReadyInMs,
     };
@@ -1142,21 +1157,27 @@ export class KeyPool {
     await this.ensureFreshProviders(false);
 
     const now = Date.now();
+    const expiryBuffer = resolveExpiryBufferMs(this.config.expiryBufferMs);
     const statuses: Record<string, readonly KeyPoolAccountStatus[]> = {};
 
     for (const [providerId, providerState] of this.providers.entries()) {
       statuses[providerId] = providerState.accounts.map((credential) => {
         const key = accountStateKey(credential);
         const cooldownUntil = this.cooldownByAccountKey.get(key);
+        const disabled = this.disabledAccountKeys.has(key);
+        const expired = typeof credential.expiresAt === "number" && credential.expiresAt <= now + expiryBuffer;
         const inFlight = (this.inFlightByAccountKey.get(key) ?? 0) > 0;
-        const available = (cooldownUntil ?? 0) <= now;
+        const available = !disabled && !expired && (cooldownUntil ?? 0) <= now;
         return {
           providerId,
           accountId: credential.accountId,
           authType: credential.authType,
           available,
+          disabled,
+          expired,
           inFlight,
           cooldownUntil,
+          expiresAt: credential.expiresAt,
           nextReadyInMs: available || cooldownUntil === undefined ? 0 : Math.max(cooldownUntil - now, 0),
         };
       });

--- a/src/lib/provider-strategy/strategies/openai.ts
+++ b/src/lib/provider-strategy/strategies/openai.ts
@@ -27,6 +27,7 @@ import {
  */
 const CODEX_UNSUPPORTED_PARAMS = [
   "max_output_tokens",
+  "prompt_cache_retention",
   "temperature",
   "top_p",
   "presence_penalty",

--- a/src/routes/bridge/lease.ts
+++ b/src/routes/bridge/lease.ts
@@ -40,11 +40,17 @@ type BridgeAccountDescriptor = {
   readonly providerId: string;
   readonly accountId: string;
   readonly authType: "api_key" | "oauth_bearer";
+  readonly available: true;
   readonly expiresAt?: number;
   readonly chatgptAccountId?: string;
   readonly planType?: string;
   readonly credentialMobility: "importable" | "access_token_only";
 };
+
+async function bridgeAccountIsAvailable(deps: BridgeLeaseRouteDeps, providerId: string, accountId: string): Promise<boolean> {
+  const accounts = await deps.keyPool.getRequestOrder(providerId).catch(() => []);
+  return accounts.some((account) => account.accountId === accountId);
+}
 
 export async function registerBridgeLeaseRoutes(
   app: FastifyInstance,
@@ -74,21 +80,36 @@ export async function registerBridgeLeaseRoutes(
     const limit = typeof limitRaw === "number" && Number.isFinite(limitRaw) ? Math.max(1, Math.min(limitRaw, 5000)) : 5000;
 
     try {
-      const accounts = await deps.keyPool.getAllAccounts(providerId);
+      const accounts = await deps.keyPool.getRequestOrder(providerId).catch(() => []);
       const descriptors: BridgeAccountDescriptor[] = accounts
         .slice(0, limit)
         .map((account): BridgeAccountDescriptor => ({
           providerId: account.providerId,
           accountId: account.accountId,
           authType: account.authType,
+          available: true,
           expiresAt: account.expiresAt,
           chatgptAccountId: account.chatgptAccountId,
           planType: account.planType,
           credentialMobility: account.authType === "oauth_bearer" ? "access_token_only" : "importable",
         }))
         .sort((a, b) => a.accountId.localeCompare(b.accountId));
+      const status = await deps.keyPool.getStatus(providerId).catch(() => undefined);
 
-      reply.send({ providerId, accounts: descriptors });
+      reply.send({
+        providerId,
+        accounts: descriptors,
+        health: status
+          ? {
+              totalAccounts: status.totalAccounts,
+              availableAccounts: status.availableAccounts,
+              cooldownAccounts: status.cooldownAccounts,
+              disabledAccounts: status.disabledAccounts,
+              expiredAccounts: status.expiredAccounts,
+              nextReadyInMs: status.nextReadyInMs,
+            }
+          : undefined,
+      });
     } catch (error) {
       reply.code(502).send({ error: "bridge_accounts_failed", detail: toErrorMessage(error) });
     }
@@ -109,11 +130,16 @@ export async function registerBridgeLeaseRoutes(
     try {
       const statuses = await deps.keyPool.getAllStatuses();
       const providers = Object.values(statuses)
+        .filter((status) => status.availableAccounts > 0)
         .map((status) => ({
           providerId: status.providerId,
           authType: status.authType,
           totalAccounts: status.totalAccounts,
           availableAccounts: status.availableAccounts,
+          cooldownAccounts: status.cooldownAccounts,
+          disabledAccounts: status.disabledAccounts,
+          expiredAccounts: status.expiredAccounts,
+          nextReadyInMs: status.nextReadyInMs,
           credentialMobility: status.authType === "oauth_bearer" ? "access_token_only" : "importable",
         }))
         .sort((a, b) => a.providerId.localeCompare(b.providerId));
@@ -161,6 +187,7 @@ export async function registerBridgeLeaseRoutes(
 
         if (needsRefresh && hasRefreshToken && providerMatchesOpenAi && deps.refreshOpenAiOauthAccounts) {
           await deps.refreshOpenAiOauthAccounts(exported.accountId).catch(() => undefined);
+          await deps.keyPool.warmup().catch(() => undefined);
           const refreshed = await findCredentialForFederationExport(deps.credentialStore, providerId, accountId);
           if (refreshed) {
             exported = refreshed;
@@ -169,6 +196,11 @@ export async function registerBridgeLeaseRoutes(
       }
 
       if (exported) {
+        if (!await bridgeAccountIsAvailable(deps, providerId, accountId)) {
+          reply.code(409).send({ error: "credential_account_unavailable" });
+          return;
+        }
+
         const sanitized: FederationCredentialExport = exported.authType === "oauth_bearer"
           ? { ...exported, refreshToken: undefined }
           : exported;
@@ -181,6 +213,11 @@ export async function registerBridgeLeaseRoutes(
       const candidate = poolAccounts.find((entry) => entry.accountId === accountId);
       if (!candidate) {
         reply.code(404).send({ error: "credential_account_not_found" });
+        return;
+      }
+
+      if (!await bridgeAccountIsAvailable(deps, providerId, accountId)) {
+        reply.code(409).send({ error: "credential_account_unavailable" });
         return;
       }
 

--- a/src/routes/bridge/lease.ts
+++ b/src/routes/bridge/lease.ts
@@ -48,7 +48,7 @@ type BridgeAccountDescriptor = {
 };
 
 async function bridgeAccountIsAvailable(deps: BridgeLeaseRouteDeps, providerId: string, accountId: string): Promise<boolean> {
-  const accounts = await deps.keyPool.getRequestOrder(providerId).catch(() => []);
+  const accounts = await deps.keyPool.getRequestOrder(providerId);
   return accounts.some((account) => account.accountId === accountId);
 }
 
@@ -80,7 +80,7 @@ export async function registerBridgeLeaseRoutes(
     const limit = typeof limitRaw === "number" && Number.isFinite(limitRaw) ? Math.max(1, Math.min(limitRaw, 5000)) : 5000;
 
     try {
-      const accounts = await deps.keyPool.getRequestOrder(providerId).catch(() => []);
+      const accounts = await deps.keyPool.getRequestOrder(providerId);
       const descriptors: BridgeAccountDescriptor[] = accounts
         .slice(0, limit)
         .map((account): BridgeAccountDescriptor => ({
@@ -94,7 +94,7 @@ export async function registerBridgeLeaseRoutes(
           credentialMobility: account.authType === "oauth_bearer" ? "access_token_only" : "importable",
         }))
         .sort((a, b) => a.accountId.localeCompare(b.accountId));
-      const status = await deps.keyPool.getStatus(providerId).catch(() => undefined);
+      const status = await deps.keyPool.getStatus(providerId);
 
       reply.send({
         providerId,

--- a/src/tests/key-pool.test.ts
+++ b/src/tests/key-pool.test.ts
@@ -276,6 +276,72 @@ test("refresh ordering omits accounts that are still cooling down", async () => 
   );
 });
 
+
+test("status and account health exclude expired disabled and cooling OAuth accounts", async () => {
+  await withKeysFile(
+    {
+      providers: {
+        openai: {
+          auth: "oauth_bearer",
+          accounts: [
+            { id: "oa-ready", access_token: "oa-token-ready", expires_at: 1_700_000_120_000 },
+            { id: "oa-expired", access_token: "oa-token-expired", expires_at: 1_699_999_999_000 },
+            { id: "oa-disabled", access_token: "oa-token-disabled", expires_at: 1_700_000_120_000 },
+            { id: "oa-cooldown", access_token: "oa-token-cooldown", expires_at: 1_700_000_120_000 },
+          ],
+        },
+      },
+    },
+    async (keysFilePath) => {
+      const originalNow = Date.now;
+      Date.now = () => 1_700_000_000_000;
+
+      try {
+        const keyPool = new KeyPool({
+          keysFilePath,
+          reloadIntervalMs: 10,
+          defaultCooldownMs: 1_000,
+          defaultProviderId: "openai",
+          cooldownJitterFactor: 0,
+          disabledStore: {
+            async loadDisabledAccounts() {
+              return new Set(["openai\0oa-disabled"]);
+            },
+            async setAccountDisabled() {
+              return;
+            },
+          },
+        });
+
+        await keyPool.warmup();
+        const cooldown = (await keyPool.getAllAccounts("openai")).find((account) => account.accountId === "oa-cooldown")!;
+        keyPool.markRateLimited(cooldown, 60_000);
+
+        const requestOrder = await keyPool.getRequestOrder("openai");
+        assert.deepEqual(requestOrder.map((account) => account.accountId), ["oa-ready"]);
+
+        const status = await keyPool.getStatus("openai");
+        assert.equal(status.totalAccounts, 4);
+        assert.equal(status.availableAccounts, 1);
+        assert.equal(status.expiredAccounts, 1);
+        assert.equal(status.disabledAccounts, 1);
+        assert.equal(status.cooldownAccounts, 1);
+
+        const accountStatuses = (await keyPool.getAllAccountStatuses()).openai ?? [];
+        const byId = new Map(accountStatuses.map((account) => [account.accountId, account]));
+        assert.equal(byId.get("oa-ready")?.available, true);
+        assert.equal(byId.get("oa-expired")?.expired, true);
+        assert.equal(byId.get("oa-expired")?.available, false);
+        assert.equal(byId.get("oa-disabled")?.disabled, true);
+        assert.equal(byId.get("oa-disabled")?.available, false);
+        assert.equal(byId.get("oa-cooldown")?.available, false);
+      } finally {
+        Date.now = originalNow;
+      }
+    },
+  );
+});
+
 test("weighted shuffle rescales remaining weight mass between picks", async () => {
   await withKeysFile(
     {

--- a/src/tests/key-pool.test.ts
+++ b/src/tests/key-pool.test.ts
@@ -331,9 +331,9 @@ test("status and account health exclude expired disabled and cooling OAuth accou
         const byId = new Map(accountStatuses.map((account) => [account.accountId, account]));
         assert.equal(byId.get("oa-ready")?.available, true);
         assert.equal(byId.get("oa-expired")?.expired, true);
-        assert.equal(byId.get("oa-expired")?.available, false);
+        assert.equal(byId.get("oa-expired")?.available, true, "account-status available remains cooldown-only for UI compatibility");
         assert.equal(byId.get("oa-disabled")?.disabled, true);
-        assert.equal(byId.get("oa-disabled")?.available, false);
+        assert.equal(byId.get("oa-disabled")?.available, true, "disabled is reported separately from cooldown readiness");
         assert.equal(byId.get("oa-cooldown")?.available, false);
       } finally {
         Date.now = originalNow;

--- a/src/tests/proxy.test.ts
+++ b/src/tests/proxy.test.ts
@@ -7742,7 +7742,7 @@ test("openai passthrough still reaches codex when provider catalog lookup is una
   );
 });
 
-test("openai passthrough strips max_output_tokens for codex path (regression: unsupported parameter)", async () => {
+test("openai passthrough strips codex-unsupported response parameters", async () => {
   let observedBody: Record<string, unknown> | undefined;
 
   await withProxyApp(
@@ -7786,6 +7786,7 @@ test("openai passthrough strips max_output_tokens for codex path (regression: un
           input: [{ role: "user", content: [{ type: "input_text", text: "hello" }] }],
           instructions: "",
           max_output_tokens: 32000,
+          prompt_cache_retention: "24h",
           stream: true
         }
       });
@@ -7793,6 +7794,7 @@ test("openai passthrough strips max_output_tokens for codex path (regression: un
       assert.equal(response.statusCode, 200);
       assert.ok(observedBody);
       assert.equal(observedBody.max_output_tokens, undefined, "max_output_tokens must be stripped for codex path");
+      assert.equal(observedBody.prompt_cache_retention, undefined, "prompt_cache_retention must be stripped for codex path");
     }
   );
 });


### PR DESCRIPTION
Promotes PR #257 to production.\n\nIncludes bridge health/capacity advertising, lease endpoint availability filtering, Codex prompt_cache_retention stripping, and bridge autostart ordering fix.\n\nOperational verification already passed on production with Knoxx gpt-5.5 full token contract restored.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced credential management with availability and health status tracking
  * New API endpoints for accessing credential accounts, providers, and export functionality
  * Improved account filtering that excludes expired and disabled credentials

* **Bug Fixes**
  * Properly filters unavailable credentials from session and account selection
  * Returns error (HTTP 409) when requested credential account is unavailable

<!-- end of auto-generated comment: release notes by coderabbit.ai -->