### PR TITLE
fix: address bridge lease review findings

### DIFF
--- a/src/lib/key-pool.ts
+++ b/src/lib/key-pool.ts
@@ -1167,7 +1167,7 @@ export class KeyPool {
         const disabled = this.disabledAccountKeys.has(key);
         const expired = typeof credential.expiresAt === "number" && credential.expiresAt <= now + expiryBuffer;
         const inFlight = (this.inFlightByAccountKey.get(key) ?? 0) > 0;
-        const available = !disabled && !expired && (cooldownUntil ?? 0) <= now;
+        const available = (cooldownUntil ?? 0) <= now;
         return {
           providerId,
           accountId: credential.accountId,

--- a/src/routes/bridge/lease.ts
+++ b/src/routes/bridge/lease.ts
@@ -48,7 +48,7 @@ type BridgeAccountDescriptor = {
 };
 
 async function bridgeAccountIsAvailable(deps: BridgeLeaseRouteDeps, providerId: string, accountId: string): Promise<boolean> {
-  const accounts = await deps.keyPool.getRequestOrder(providerId).catch(() => []);
+  const accounts = await deps.keyPool.getRequestOrder(providerId);
   return accounts.some((account) => account.accountId === accountId);
 }
 
@@ -80,7 +80,7 @@ export async function registerBridgeLeaseRoutes(
     const limit = typeof limitRaw === "number" && Number.isFinite(limitRaw) ? Math.max(1, Math.min(limitRaw, 5000)) : 5000;
 
     try {
-      const accounts = await deps.keyPool.getRequestOrder(providerId).catch(() => []);
+      const accounts = await deps.keyPool.getRequestOrder(providerId);
       const descriptors: BridgeAccountDescriptor[] = accounts
         .slice(0, limit)
         .map((account): BridgeAccountDescriptor => ({
@@ -94,7 +94,7 @@ export async function registerBridgeLeaseRoutes(
           credentialMobility: account.authType === "oauth_bearer" ? "access_token_only" : "importable",
         }))
         .sort((a, b) => a.accountId.localeCompare(b.accountId));
-      const status = await deps.keyPool.getStatus(providerId).catch(() => undefined);
+      const status = await deps.keyPool.getStatus(providerId);
 
       reply.send({
         providerId,

--- a/src/tests/key-pool.test.ts
+++ b/src/tests/key-pool.test.ts
@@ -331,9 +331,9 @@ test("status and account health exclude expired disabled and cooling OAuth accou
         const byId = new Map(accountStatuses.map((account) => [account.accountId, account]));
         assert.equal(byId.get("oa-ready")?.available, true);
         assert.equal(byId.get("oa-expired")?.expired, true);
-        assert.equal(byId.get("oa-expired")?.available, false);
+        assert.equal(byId.get("oa-expired")?.available, true, "account-status available remains cooldown-only for UI compatibility");
         assert.equal(byId.get("oa-disabled")?.disabled, true);
-        assert.equal(byId.get("oa-disabled")?.available, false);
+        assert.equal(byId.get("oa-disabled")?.available, true, "disabled is reported separately from cooldown readiness");
         assert.equal(byId.get("oa-cooldown")?.available, false);
       } finally {
         Date.now = originalNow;


### PR DESCRIPTION
Addresses CodeRabbit review on promotion PR #258.\n\n- Restores per-account status `available` to cooldown-only semantics for UI compatibility while keeping disabled/expired separate fields.\n- Lets bridge lease `getRequestOrder`/`getStatus` failures propagate to the route 502 handlers instead of returning fake empty availability.\n\nValidation:\n- eslint targeted files\n- tsx key-pool tests\n- typecheck\n- build\n- node key-pool + federation bridge tests\n- focused proxy Codex unsupported-param regression test