### PR TITLE
docs(kanban): embedding backend stability + load distribution tasks

### DIFF
--- a/kanban/embedding-routing-stability/embed-context-size-policy.md
+++ b/kanban/embedding-routing-stability/embed-context-size-policy.md
@@ -54,8 +54,12 @@ The already-correct `recommendedNumCtx` is ignored on the happy path.
    - Add an embedding context-size knob to policy (e.g. in `20-provider-capabilities.edn`),
      resolvable **per provider-route and/or per model-family** — so a constrained box
      (`ollama-lan`) can cap embeddings at, say, **8192**, while a roomy backend may allow more.
-   - Resolution order: explicit request `num_ctx` → policy per-route cap → policy per-family cap →
-     conservative global default (propose **8192**, replacing the 256k default).
+   - Resolve the **policy cap** in order: per-route cap → per-family cap → conservative global
+     default (propose **8192**, replacing the 256k default).
+   - A request-supplied `num_ctx` is a *desired* value, never an override of the cap. Always
+     clamp it: `effective_ctx = min(requested_num_ctx ?? recommendedNumCtx, policy_cap)`. A
+     request may shrink `num_ctx` but can never exceed the resolved cap — otherwise a client
+     could bypass the very safeguard this task introduces. (Per CodeRabbit on #274.)
    - Keep the overflow guard: if input genuinely exceeds the cap, error clearly
      (`embed_context_overflow`) rather than silently ballooning the cache.
 3. Plumb the resolved cap through `embeddings.ts` → `ensureNativeOllamaEmbedContextFits`

--- a/kanban/embedding-routing-stability/embed-context-size-policy.md
+++ b/kanban/embedding-routing-stability/embed-context-size-policy.md
@@ -1,0 +1,77 @@
+---
+uuid: "512e802d-bfd3-44b9-9920-0d749591033e"
+title: "Define embedding context size (num_ctx) through policy + fix oversized default"
+status: incoming
+priority: P1
+labels: ["embeddings", "routing", "num_ctx", "policy", "reliability"]
+created_at: "2026-06-08T00:53:30.000Z"
+source: "kanban/embedding-routing-stability/embed-context-size-policy.md"
+category: "routing"
+parent: "22e8ce84-ab36-43c8-b0e8-91b3aceb598f"
+---
+
+# Define embedding context size (num_ctx) through policy
+
+Part of epic `22e8ce84`. Directly reduces the memory pressure behind the ollama-lan wedge (`3e607555`).
+
+## Problem — proxx requests the full 32k context for tiny embeds
+
+For a *normal* (non-overflow) embedding, proxx sends ollama the model's **entire** context window
+as `num_ctx`, forcing a 32k-token KV cache allocation for a handful of input tokens. On a hot,
+shared GPU box this is a major, pointless memory cost and a contributor to runner instability.
+
+### Evidence
+- LAN box loaded `qwen3-embedding:0.6b` at `context_length: 32768` (`/api/ps`, `/api/show`).
+- OpenPlanner's embed inputs are tiny: chunk cap `EMBED_MAX_CHARS=6000` (~1500 tokens); search
+  queries are a few tokens. OpenPlanner never requests a large context — proxx inflates it.
+- proxx default ceiling `embedMaxContextTokens = 262144` (256k) — `src/lib/config.ts:530`
+  (`EMBED_MAX_CONTEXT_TOKENS`). Effectively "no ceiling."
+
+### Root cause (the bug)
+`src/routes/embeddings.ts` computes `embedBudget` via `ensureNativeOllamaEmbedContextFits`
+(`src/lib/ollama-context.ts`), which returns:
+- `availableContextTokens = contextLength` (the full model context, **32768**)
+- `recommendedNumCtx = min(contextLength, max(4096, roundUpToStep(inputTokens + 512)))`
+  (correctly input-sized — e.g. ~4096 for small inputs)
+
+But the dispatch only uses the recommended value in the overflow branch:
+```js
+const autoNumCtx = embedBudget && embedBudget.requiredContextTokens > embedBudget.availableContextTokens
+  ? Math.min(maxContextTokens, embedBudget.recommendedNumCtx)
+  : undefined;
+// ...
+nativeEmbedToOllamaRequest({ ...body, model }, autoNumCtx ?? embedBudget?.availableContextTokens)
+```
+In the common case `autoNumCtx` is `undefined`, so it passes `availableContextTokens` (**32768**),
+and `nativeEmbedToOllamaRequest` (`src/lib/ollama-native.ts`) sets `options.num_ctx: 32768`.
+The already-correct `recommendedNumCtx` is ignored on the happy path.
+
+## Proposed changes
+
+1. **Fix the default path:** size `num_ctx` to the input on every embed (use `recommendedNumCtx`,
+   not `availableContextTokens`). The full-context fallback is wrong for embeddings.
+2. **Make the ceiling policy-defined**, not a 256k env default:
+   - Add an embedding context-size knob to policy (e.g. in `20-provider-capabilities.edn`),
+     resolvable **per provider-route and/or per model-family** — so a constrained box
+     (`ollama-lan`) can cap embeddings at, say, **8192**, while a roomy backend may allow more.
+   - Resolution order: explicit request `num_ctx` → policy per-route cap → policy per-family cap →
+     conservative global default (propose **8192**, replacing the 256k default).
+   - Keep the overflow guard: if input genuinely exceeds the cap, error clearly
+     (`embed_context_overflow`) rather than silently ballooning the cache.
+3. Plumb the resolved cap through `embeddings.ts` → `ensureNativeOllamaEmbedContextFits`
+   (clamp `recommendedNumCtx`/`maxContextTokens` to it) → `nativeEmbedToOllamaRequest`.
+
+## Acceptance criteria
+- A small embedding request results in ollama loading/running at a small `num_ctx` (≤ policy cap,
+  e.g. 4096–8192), verified via `/api/ps` `context_length` on the LAN box — **not 32768**.
+- The cap is changeable in policy (EDN) per provider-route / model-family without a code change,
+  and takes effect on restart.
+- Inputs above the cap fail fast with a clear overflow error, not a silent 32k allocation.
+- Default global embedding `num_ctx` ceiling is sane (≤ 8192), not 262144.
+
+## References
+- `src/routes/embeddings.ts` (autoNumCtx / availableContextTokens dispatch)
+- `src/lib/ollama-context.ts` (`ensureNativeOllamaEmbedContextFits`, `recommendedNumCtx`)
+- `src/lib/ollama-native.ts` (`nativeEmbedToOllamaRequest` → `options.num_ctx`)
+- `src/lib/config.ts:530` (`embedMaxContextTokens` default 262144)
+- `resources/policies/runtime/20-provider-capabilities.edn` (where the cap should live)

--- a/kanban/embedding-routing-stability/embed-per-attempt-timeout-failover.md
+++ b/kanban/embedding-routing-stability/embed-per-attempt-timeout-failover.md
@@ -1,0 +1,46 @@
+---
+uuid: "7c1fd7e6-5c23-4e30-ba1d-8f7a78d230af"
+title: "Per-attempt embed timeout + fast failover (prereq for distribution)"
+status: incoming
+priority: P1
+labels: ["embeddings", "routing", "timeout", "reliability"]
+created_at: "2026-06-08T00:44:38.000Z"
+source: "kanban/embedding-routing-stability/embed-per-attempt-timeout-failover.md"
+category: "routing"
+parent: "22e8ce84-ab36-43c8-b0e8-91b3aceb598f"
+---
+
+# Per-attempt embed timeout + fast failover
+
+Part of epic `22e8ce84`. **Prerequisite for `dd2ab058` (distribution).**
+
+## Problem
+When an embedding provider hangs (ollama-lan wedge), proxx does not bound the single attempt —
+the request stalled for the full client timeout (observed 30–40s+) with no fall-through to the
+next provider. A hung provider should be abandoned in ~1–3s and the next candidate tried, not
+allowed to consume the whole request budget. Without this, even perfect weighting (`dd2ab058`)
+will still stall on a wedged box.
+
+Note the asymmetry observed: dead docker containers (`llamacpp-embed`, `ollama`) fast-fail with
+`fetch failed` instantly, but a wedged-but-reachable provider (`ollama-lan`) hangs — so the timeout
+must cover the *slow/hung* case, distinct from connection failures which already fall through fast.
+
+## Proposed changes
+1. Wrap each embedding provider attempt in an `AbortSignal.timeout(perAttemptMs)` (small, e.g.
+   2–3s for the preflight `ensureNativeOllamaEmbedContextFits` and a separate bound for the embed
+   call), independent of the overall request timeout.
+2. On per-attempt timeout, classify as a failure → score the route down (`618f8638`) → advance to
+   the next candidate immediately.
+3. Make the preflight (`ensureNativeOllamaEmbedContextFits`) itself bounded — it currently appears
+   to be where the ollama-lan path stalled (no provider-attempt log line emitted before the hang).
+
+## Acceptance criteria
+- A single wedged provider adds at most `perAttemptMs` to a request before failover, not the full
+  request timeout.
+- A request with one hung provider and one healthy provider succeeds in roughly
+  `perAttemptMs + healthy latency`.
+- Per-attempt timeout is configurable and defaulted conservatively.
+
+## References
+- `src/routes/embeddings.ts` (candidate loop, `ensureNativeOllamaEmbedContextFits` preflight)
+- `src/lib/ollama-context.ts`

--- a/kanban/embedding-routing-stability/embed-provider-inference-health.md
+++ b/kanban/embedding-routing-stability/embed-provider-inference-health.md
@@ -1,0 +1,45 @@
+---
+uuid: "618f8638-c7ff-4a41-ba6a-605266cc87b3"
+title: "Health-score embedding providers by real inference (control plane lies)"
+status: incoming
+priority: P1
+labels: ["embeddings", "routing", "health", "reliability"]
+created_at: "2026-06-08T00:44:38.000Z"
+source: "kanban/embedding-routing-stability/embed-provider-inference-health.md"
+category: "routing"
+parent: "22e8ce84-ab36-43c8-b0e8-91b3aceb598f"
+---
+
+# Health-score embedding providers by real inference
+
+Part of epic `22e8ce84`.
+
+## Problem
+The ollama-lan wedge was invisible to any control-plane health check: `/api/tags`, `/api/show`,
+`/api/ps`, `/api/version` all answered instantly while `/api/embed` hung forever. A health signal
+based on "does the provider respond" is worthless for embeddings — only an **actual embed** reveals
+a wedged runner.
+
+proxx's ACO router (`src/lib/provider-route-aco.ts`) already consumes a `healthScore`
+(`DEFAULT_HEALTH_WEIGHT = 0.55`) per credential, but for embedding provider-routes there is no
+inference-derived health input, so a black-holing provider keeps its default score and keeps
+receiving traffic.
+
+## Proposed changes
+1. Feed embedding **request outcomes** (success / `fetch failed` / timeout/hang) into a per-route
+   health + latency signal, keyed by `(providerId, baseUrl)`.
+2. Optionally add an active probe: a tiny `/v1/embeddings` (or `/api/embed`) call on a short
+   timeout that updates the health score; a hang must drive the score toward 0, not leave it neutral.
+3. Surface the score so `dd2ab058`'s distribution can deprioritize/skip unhealthy routes
+   *before* dispatch.
+
+## Acceptance criteria
+- A provider whose `/api/embed` hangs is scored unhealthy within N requests/probes and is
+  skipped, without waiting the full per-request timeout each time.
+- A recovered provider (after restart) is re-promoted automatically as success/latency recover.
+- Health derives from embedding inference, never from `/api/tags`/`/api/ps`.
+
+## References
+- `src/lib/provider-route-aco.ts` (health/latency/recency/confidence weighting)
+- `src/lib/provider-route-pheromone-store.ts`
+- `src/routes/embeddings.ts` (per-attempt loop where outcomes are observed)

--- a/kanban/embedding-routing-stability/embed-provider-load-distribution.md
+++ b/kanban/embedding-routing-stability/embed-provider-load-distribution.md
@@ -1,0 +1,53 @@
+---
+uuid: "dd2ab058-5423-4c81-8f0a-8d6af6a02828"
+title: "Provider-level load distribution for embeddings (ACO-at-route)"
+status: incoming
+priority: P2
+labels: ["embeddings", "routing", "load-balancing", "aco"]
+created_at: "2026-06-08T00:44:38.000Z"
+source: "kanban/embedding-routing-stability/embed-provider-load-distribution.md"
+category: "routing"
+parent: "22e8ce84-ab36-43c8-b0e8-91b3aceb598f"
+---
+
+# Provider-level load distribution for embeddings
+
+Part of epic `22e8ce84`. Depends on `7c1fd7e6` (per-attempt timeout) and `618f8638` (inference health).
+
+## Problem
+Embeddings use strict ordered failover: `:provider-order/embeddings = ["llamacpp-embed" "ollama"
+"ollama-lan"]` means "always try #1, fall to #2 only on failure." All traffic piles on the first
+healthy provider; a dead-but-first provider wastes a round-trip every request. When multiple
+embedding backends are available we want them *shared*, not stacked.
+
+## Two approaches (recommend A)
+
+### A. Reuse the ACO router at the provider-route level (recommended, adaptive)
+proxx already scores by health (0.55) / latency (0.25) / recency (0.1) / confidence (0.1) and does
+`weightedRandomOrder` — but only for **account** selection within a provider. Extend that scoring
+to choose **among embedding provider-routes** so fast/healthy backends get proportionally more
+traffic and a slow/wedged one automatically sheds load. Adaptive: reacts to a provider going slow
+mid-flight, not just hard-down.
+
+### B. Weighted / balanced preference-order kind (smaller, static)
+Add a `:balanced` (or weighted) variant alongside `:preference-order` so `:provider-order/embeddings`
+can express "split across these N healthy providers" with optional weights (e.g. CPU stack 30%,
+GPU box 70%). Smaller policy-engine change, but static — won't react to live latency the way ACO does.
+
+## Hard prerequisites (do not start before these land)
+- `7c1fd7e6`: per-attempt timeout + fast failover — otherwise a hung provider stalls the whole
+  request regardless of weighting.
+- `618f8638`: inference-derived health — otherwise the weighter sends traffic to black-holing
+  providers because their score stays neutral.
+
+## Acceptance criteria
+- With ≥2 healthy embedding providers, traffic is observably split (not 100% to one).
+- A provider that degrades (rising latency / errors) receives proportionally less traffic without
+  config changes.
+- A hard-down provider is excluded from the rotation, not retried-first every request.
+
+## References
+- `src/lib/provider-route-aco.ts`, `src/lib/provider-route-pheromone-store.ts`
+- `resources/policies/runtime/20-provider-capabilities.edn` (`:preference-order` semantics)
+- `resources/policies/runtime/40-strategy-selection.edn`, `50-account-selection.edn`, `90-router.edn`
+- `kanban/audits/2026-04-10-pheromone-routing-failure-analysis.md`

--- a/kanban/embedding-routing-stability/embedding-stability-epic.md
+++ b/kanban/embedding-routing-stability/embedding-stability-epic.md
@@ -1,0 +1,68 @@
+---
+uuid: "22e8ce84-ab36-43c8-b0e8-91b3aceb598f"
+title: "Epic: Embedding backend stability + proxx load distribution"
+status: incoming
+priority: P1
+labels: ["epic", "embeddings", "routing", "reliability"]
+created_at: "2026-06-08T00:44:38.000Z"
+source: "kanban/embedding-routing-stability/embedding-stability-epic.md"
+category: "routing"
+---
+
+# Epic: Embedding backend stability + proxx load distribution
+
+## Trigger
+
+knoxx-backend spammed `openplanner is down ... POST /v1/search/vector ... This operation was aborted`.
+Investigation showed **OpenPlanner, proxx, and Mongo were all healthy** — the outage was
+purely the **embedding tier**, mislabeled as an OpenPlanner outage because the failure surfaced
+as an aborted vector search.
+
+## Failure chain (observed 2026-06-08)
+
+knoxx → OpenPlanner `/v1/search/vector` → query embedding via proxx (`/v1/embeddings`,
+`qwen3-embedding:0.6b`) → proxx tries embedding providers in strict order:
+
+| Provider | Target | State | Symptom |
+|---|---|---|---|
+| `llamacpp-embed` | `http://llamacpp-embed:8081` | container **exited 3 days ago** | instant `fetch failed` |
+| `ollama` | `http://ollama:11434` | container **not running** | instant `fetch failed` |
+| `ollama-lan` | `http://192.168.12.68:11434` | box up, **embed runner wedged** | `/api/embed` hangs 30s+ |
+
+With no provider returning, OpenPlanner's 30s embed timeout fired, the vector search hung,
+and knoxx's 60s client `AbortError` mislogged it as "openplanner is down."
+
+### ollama-lan wedge specifics
+- `/api/tags`, `/api/show`, `/api/ps`, `/api/generate` all answered instantly (control plane fine)
+- `/api/embed` and legacy `/api/embeddings` hung indefinitely (inference dead)
+- `/api/ps` reported the model loaded with `size_vram: 0` and `expires_at` already in the past
+- Diagnosis: keep-alive expired → ollama tried to unload the runner → GPU-backed runner
+  wedged (hot GPU / driver instability) → stuck at `Stopping…` → all new embed requests
+  queued behind a dead runner. Cleared only by restarting ollama on the LAN box.
+
+## Two problems to fix
+
+1. **Stability** — the load→expire→unload-wedge cycle on a hot GPU, plus the fact that
+   `/api/tags`/`/api/ps` answer while inference is dead, so health checks didn't catch it.
+2. **Distribution** — embeddings use strict ordered failover (`:provider-order/embeddings`),
+   so all traffic piles on provider #1 and a dead-but-first provider wastes a round-trip on
+   every request. proxx already has adaptive routing (`provider-route-aco.ts`,
+   health/latency/recency weighting + `weightedRandomOrder`) but only at *account* selection,
+   not provider-vs-provider for embeddings.
+
+## Child tasks
+- [ ] `3e607555` Stabilize ollama-lan embed runner (keep-alive resident + wedge watchdog)
+- [ ] `fb515e6c` Revive llamacpp-stack as stable CPU embed primary
+- [ ] `618f8638` Health-score embedding providers by real inference (control plane lies)
+- [ ] `7c1fd7e6` Per-attempt embed timeout + fast failover (prereq for distribution)
+- [ ] `dd2ab058` Provider-level load distribution for embeddings (ACO-at-route)
+- [ ] `512e802d` Define embedding context size (num_ctx) through policy + fix oversized default
+
+## Cross-repo follow-up (not proxx)
+- knoxx should not surface an embedding-tier failure as "openplanner is down"; the
+  `log-openplanner-down!` path in `clients/openplanner.cljs` over-attributes aborts.
+
+## References
+- `kanban/audits/2026-04-10-pheromone-routing-failure-analysis.md` (prior ACO routing audit)
+- `resources/policies/runtime/20-provider-capabilities.edn` (`:provider-order/embeddings`, `:request-surface/embeddings`)
+- `src/routes/embeddings.ts`, `src/lib/provider-routing.ts`, `src/lib/provider-route-aco.ts`

--- a/kanban/embedding-routing-stability/revive-llamacpp-stack-cpu-embed.md
+++ b/kanban/embedding-routing-stability/revive-llamacpp-stack-cpu-embed.md
@@ -1,0 +1,37 @@
+---
+uuid: "fb515e6c-7e2f-49af-8aeb-932c38ec9b66"
+title: "Revive llamacpp-stack as stable CPU embed primary"
+status: incoming
+priority: P2
+labels: ["embeddings", "infra", "llamacpp", "reliability"]
+created_at: "2026-06-08T00:44:38.000Z"
+source: "kanban/embedding-routing-stability/revive-llamacpp-stack-cpu-embed.md"
+category: "infra"
+parent: "22e8ce84-ab36-43c8-b0e8-91b3aceb598f"
+---
+
+# Revive llamacpp-stack as stable CPU embed primary
+
+Part of epic `22e8ce84`.
+
+## Problem
+`llamacpp-embed` is the first provider in `:provider-order/embeddings` (intended primary), but
+the container `llamacpp-stack-llamacpp-embed-1` has been **Exited (0) for 3 days**. proxx fast-fails
+on it every request and falls through. The CPU llama.cpp embedding server is far more stable than
+the GPU ollama path (no load/unload-unload-wedge dynamic, no VRAM contention) and makes a better
+always-on primary, with the GPU LAN box as the fast path.
+
+## Proposed changes
+1. Bring up `services/llamacpp-stack` (`docker compose up -d`) and confirm it serves
+   OpenAI-compatible `/v1/embeddings` for `qwen3-embedding:0.6b` at `http://llamacpp-embed:8081`.
+2. Add it to compose autostart / restart policy so it survives reboots (it should not silently
+   stay exited for days).
+3. Decide the role split with ollama-lan once distribution lands (`dd2ab058`): CPU stack as the
+   stable baseline, GPU box weighted for throughput.
+4. Confirm the compact model path (`qwen3-embedding:4b`) — verify which backend actually serves
+   the 4b compact embeds; the LAN box was only confirmed to hold the 0.6b model.
+
+## Acceptance criteria
+- `llamacpp-stack-llamacpp-embed-1` is `Up (healthy)` and survives a host reboot.
+- A direct `POST http://llamacpp-embed:8081/v1/embeddings` returns vectors for 0.6b in < 1s.
+- proxx routes embeddings to it without `fetch failed`.

--- a/kanban/embedding-routing-stability/stabilize-ollama-lan-embed-runner.md
+++ b/kanban/embedding-routing-stability/stabilize-ollama-lan-embed-runner.md
@@ -1,0 +1,44 @@
+---
+uuid: "3e607555-3fce-40e0-b0cb-6bed9699a1f3"
+title: "Stabilize ollama-lan embed runner: keep-alive resident + wedge watchdog"
+status: incoming
+priority: P1
+labels: ["embeddings", "infra", "ollama", "reliability"]
+created_at: "2026-06-08T00:44:38.000Z"
+source: "kanban/embedding-routing-stability/stabilize-ollama-lan-embed-runner.md"
+category: "infra"
+parent: "22e8ce84-ab36-43c8-b0e8-91b3aceb598f"
+---
+
+# Stabilize ollama-lan embed runner
+
+Part of epic `22e8ce84`.
+
+## Problem
+The LAN ollama box (`192.168.12.68:11434`) wedged its embedding runner: after keep-alive
+expiry, ollama tried to unload `qwen3-embedding:0.6b`, the GPU-backed runner got stuck
+(`size_vram: 0`, `expires_at` in the past, `ollama ps` showing `Stopping…` indefinitely),
+and every subsequent `/api/embed` hung. Control-plane endpoints kept answering, masking it.
+
+## Proposed changes
+1. **Pin the embed model resident.** Set `OLLAMA_KEEP_ALIVE=-1` on the LAN box (or send
+   `"keep_alive": -1` on embed requests). A 0.6B Q8 model is tiny; keeping it resident removes
+   both the cold-load latency spikes and the unload-wedge trigger. **Highest-value change.**
+2. **Protect VRAM.** If the box also serves chat models, tune `OLLAMA_MAX_LOADED_MODELS` /
+   `OLLAMA_NUM_PARALLEL` so the embed model isn't evicted under pressure (eviction → reload →
+   wedge risk).
+3. **Wedge watchdog.** Add a watchdog that probes `/api/embed` with a tiny input on a short
+   timeout (NOT `/api/tags` — the control plane lies) and restarts the ollama service if the
+   probe hangs. See sibling task `618f8638` for the proxx-side health signal.
+4. **GPU root-cause capture.** Next time it wedges, before restarting, capture
+   `journalctl -u ollama`, the ollama server log, and `nvidia-smi` / `dmesg | grep -iE 'xid|nvrm|gpu'`
+   to confirm thermal vs driver Xid vs OOM. "getting toasty" suggests thermal/driver instability.
+
+## Acceptance criteria
+- Embed model stays resident across idle periods (verify `ollama ps` keeps it loaded with
+  non-zero VRAM, no `expires_at` in the past during normal operation).
+- A forced keep-alive-expiry + reload cycle does not wedge (`/api/embed` returns < 2s after reload).
+- Watchdog restarts ollama within a bounded window when `/api/embed` hangs.
+
+## Notes
+- Scope touches the LAN host config, not proxx code, but tracked here per the embedding epic.


### PR DESCRIPTION
## What
Adds an epic + 6 task cards under `kanban/embedding-routing-stability/` capturing work surfaced by a knoxx **"openplanner is down"** incident that was actually an **embedding-tier outage**.

## Why
OpenPlanner, proxx, and Mongo were all healthy. The failure: all three embedding providers were non-functional — `llamacpp-embed` and `ollama` containers down, and `ollama-lan` (`192.168.12.68:11434`) had a **wedged embed runner** (keep-alive unload stuck at `Stopping…` on a hot GPU; `/api/embed` hung while the control plane stayed green). With no embedding backend, `/v1/search/vector` hung and knoxx's client abort mislabeled it as an OpenPlanner outage.

## Cards
- **Epic** `22e8ce84` — overview + full failure chain + evidence
- `3e607555` — Stabilize ollama-lan embed runner (keep-alive resident + inference-probe watchdog)
- `fb515e6c` — Revive llamacpp-stack as stable CPU embed primary
- `618f8638` — Health-score embedding providers by **real inference** (control plane lies)
- `7c1fd7e6` — Per-attempt embed timeout + fast failover (prereq for distribution)
- `dd2ab058` — Provider-level load distribution (ACO-at-route)
- `512e802d` — Define embedding `num_ctx` via policy + fix the 32k oversized default

Docs/kanban only — no code changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added specifications for embedding backend stability improvements including provider health scoring, intelligent failover, and hang detection.
  * Documented per-attempt timeout enforcement for faster provider recovery.
  * Specified load distribution and adaptive routing strategies across embedding providers.
  * Added context sizing policy documentation for optimized request handling.
  * Documented CPU fallback support and runner stabilization procedures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->