### PR TITLE
fix(oauth-import): 2026-06 verification email + endpoints; drop hardcoded secret

### DIFF
--- a/kanban/oauth-import-verification-2026.md
+++ b/kanban/oauth-import-verification-2026.md
@@ -1,0 +1,44 @@
+---
+uuid: "53a04126-e3f0-4526-a387-68ae8038864c"
+title: "OAuth import: adapt to 2026-06 OpenAI verification email + endpoint changes"
+status: incoming
+priority: P2
+labels: ["oauth", "scripts", "maintenance"]
+created_at: "2026-06-08T01:42:23.000Z"
+source: "kanban/oauth-import-verification-2026.md"
+category: "scripts"
+---
+
+# OAuth import: adapt to 2026-06 OpenAI verification email + endpoint changes
+
+Retroactive task for working-tree changes to the OpenAI account OAuth import tooling.
+
+## Changes
+
+### `scripts/bulk-oauth-import.ts`
+- **New verification-email format (2026-06):** OpenAI now sends
+  "Enter this temporary verification code to continue: NNNNNN." Added a primary matcher for it,
+  kept the old "Your ChatGPT code is NNNNNN" matcher, and broadened the fallback matchers
+  (incl. a last-resort "code … NNNNNN" near-match).
+- **IMAP search broadened** from subject `"ChatGPT code"` to `"ChatGPT"` so the new-format mails
+  (different subject) are found.
+- **Corrected proxy endpoints:** `/api/ui/credentials/openai/oauth/browser/start` →
+  `/api/v1/credentials/openai/oauth/browser/start`; callback now posts to
+  `/api/v1/credentials/openai/oauth/browser/callback` instead of `/auth/callback`.
+- **Phone-required detection:** throw `Phone number required` when OpenAI demands a phone number
+  (so the row is reported and skipped rather than hanging).
+- **Fail-fast:** `break` the account loop on an unexpected failure instead of grinding through.
+
+### `scripts/debug-emails.cjs`
+- Ad-hoc IMAP helper for inspecting verification emails.
+- **Security:** removed a hardcoded Gmail address + app password; now reads `GMAIL_USER` /
+  `GMAIL_APP_PASSWORD` (and optional `IMAP_HOST`) from env and exits if unset.
+
+## Action item (outside the repo)
+- The previously-hardcoded Gmail app password was committed to disk in plaintext and must be
+  **revoked/rotated** in the Google account regardless of this cleanup.
+
+## Acceptance criteria
+- Import resolves codes from the 2026-06 email format end to end.
+- OAuth start/callback hit the `/api/v1/credentials/...` routes.
+- No secret is present in source; debug helper sources creds from env.

--- a/scripts/bulk-oauth-import.ts
+++ b/scripts/bulk-oauth-import.ts
@@ -150,7 +150,7 @@ async function fetchVerificationCode(
 
   const lock = await client.getMailboxLock("INBOX");
   try {
-    const existingUids = (await client.search({ subject: "ChatGPT code" })) || [];
+    const existingUids = (await client.search({ subject: "ChatGPT" })) || [];
 
     // Set our UID baseline to the newest message that is strictly before sinceDate.
     // This avoids skipping a verification email that arrives during the initial snapshot.
@@ -183,7 +183,7 @@ async function fetchVerificationCode(
 
       const lock = await client.getMailboxLock("INBOX");
       try {
-        const uids = (await client.search({ subject: "ChatGPT code" })) || [];
+        const uids = (await client.search({ subject: "ChatGPT" })) || [];
 
         const candidateUids = uids.filter((uid) => !checkedUids.has(uid));
 
@@ -215,16 +215,28 @@ async function fetchVerificationCode(
             continue;
           }
 
-          // code is in the subject: "Your ChatGPT code is XXXXXX"
+          // New format (2026-06): "Enter this temporary verification code to continue: 269944."
+          const newMatch = body.match(/(?:enter this|temporary) (?:verification )?code(?: to continue)?[:\s]+(\d{6})/i);
+          if (newMatch?.[1]) {
+            return newMatch[1];
+          }
+
+          // Old format: "Your ChatGPT code is XXXXXX"
           const subjectMatch = body.match(/Your ChatGPT code is (\d{6})/i);
           if (subjectMatch?.[1]) {
             return subjectMatch[1];
           }
 
-          // fallback: find any 6-digit code in the body
-          const codeMatch = body.match(/(?:verification code|code is|your code)[:\s]*(\d{6})/i);
+          // fallback: find any 6-digit code near "code" in the body
+          const codeMatch = body.match(/(?:verification code|code is|your code|this code)[:\s]*(\d{6})/i);
           if (codeMatch?.[1]) {
             return codeMatch[1];
+          }
+
+          // Last resort: find "code to continue: XXXXXX" or standalone "code\nXXXXXX"
+          const lastResort = body.match(/code[^a-z]{1,20}(\d{6})/i);
+          if (lastResort?.[1]) {
+            return lastResort[1];
           }
         }
       } finally {
@@ -243,7 +255,7 @@ async function fetchVerificationCode(
 // ── Proxy API calls ──
 
 async function proxyStartBrowserOAuth(): Promise<{ authorizeUrl: string; state: string }> {
-  const res = await fetch(`${PROXY_BASE}/api/ui/credentials/openai/oauth/browser/start`, {
+  const res = await fetch(`${PROXY_BASE}/api/v1/credentials/openai/oauth/browser/start`, {
     method: "POST",
     headers: {
       "content-type": "application/json",
@@ -256,7 +268,7 @@ async function proxyStartBrowserOAuth(): Promise<{ authorizeUrl: string; state: 
 }
 
 async function proxyCompleteCallback(code: string, state: string): Promise<void> {
-  const url = `${PROXY_BASE}/auth/callback?code=${encodeURIComponent(code)}&state=${encodeURIComponent(state)}`;
+  const url = `${PROXY_BASE}/api/v1/credentials/openai/oauth/browser/callback?code=${encodeURIComponent(code)}&state=${encodeURIComponent(state)}`;
   const res = await fetch(url);
   const body = await res.text();
   if (!body.includes("Successful")) {
@@ -445,6 +457,9 @@ async function automateOpenAiLogin(
   if (bodyText.includes("account has been locked") || bodyText.includes("Account locked")) {
     throw new Error("Account locked");
   }
+  if (bodyText.includes("Add your phone number") || bodyText.includes("phone number to continue")) {
+    throw new Error("Phone number required");
+  }
 
   // ── Step 4: Email verification (if required) ──
   if (curUrl.includes("email-verification") || bodyText.includes("Check your inbox")) {
@@ -518,6 +533,9 @@ async function automateOpenAiLogin(
     if (bText.includes("Authentication Error")) {
       const detail = bText.slice(0, 240).replace(/\s+/g, " ").trim();
       throw new Error(`OpenAI authentication error: ${detail}`);
+    }
+    if (bText.includes("Add your phone number") || bText.includes("phone number to continue") || page.url().includes("add-phone")) {
+      throw new Error("Phone number required");
     }
 
     if (getCapture?.().code) {
@@ -696,6 +714,7 @@ async function main(): Promise<void> {
         } else {
           console.error(`  FAILED: ${msg}\n`);
           results.push({ email: row.username, status: `error: ${msg.slice(0, 120)}` });
+          break;
         }
       } finally {
         await context.close();

--- a/scripts/debug-emails.cjs
+++ b/scripts/debug-emails.cjs
@@ -1,0 +1,40 @@
+// Ad-hoc IMAP debug helper for inspecting OpenAI verification emails.
+// Credentials come from env — never hardcode them:
+//   GMAIL_USER=you@gmail.com GMAIL_APP_PASSWORD='xxxx xxxx xxxx xxxx' node scripts/debug-emails.cjs
+const { ImapFlow } = require("imapflow");
+
+const GMAIL_USER = process.env.GMAIL_USER;
+const GMAIL_APP_PASSWORD = process.env.GMAIL_APP_PASSWORD;
+if (!GMAIL_USER || !GMAIL_APP_PASSWORD) {
+  console.error("Set GMAIL_USER and GMAIL_APP_PASSWORD env vars before running.");
+  process.exit(1);
+}
+
+(async () => {
+  const client = new ImapFlow({
+    host: process.env.IMAP_HOST || "imap.gmail.com", port: 993, secure: true,
+    auth: { user: GMAIL_USER, pass: GMAIL_APP_PASSWORD },
+    logger: false, socketTimeout: 10000, connectionTimeout: 10000,
+  });
+  await client.connect();
+  const lock = await client.getMailboxLock("INBOX");
+  try {
+    const uids = await client.search({ subject: "temporary ChatGPT" });
+    console.log("Found:", uids?.length);
+    const uid = uids[uids.length - 1];
+    const msg = await client.fetchOne(uid, { source: true, envelope: true });
+    console.log("Subject:", msg.envelope?.subject);
+    console.log("To:", msg.envelope?.to?.[0]?.address);
+    const full = msg.source?.toString("utf8") || "";
+    // Print lines containing a 6-digit number
+    const lines = full.split(/\r?\n/);
+    for (let i = 0; i < lines.length; i++) {
+      if (/\d{6}/.test(lines[i])) {
+        console.log(`line ${i}: ${lines[i].slice(0, 200)}`);
+      }
+    }
+    // Also try matching the whole thing
+    const m = full.match(/\d{6}/g);
+    console.log("\nAll 6-digit matches:", m);
+  } finally { lock.release(); await client.logout(); }
+})().catch(e => { console.error("FATAL:", e.message); process.exit(1); });


### PR DESCRIPTION
Retroactive task for working-tree changes to the OpenAI account OAuth import tooling.

## `scripts/bulk-oauth-import.ts`
- **2026-06 email format:** match "Enter this temporary verification code to continue: NNNNNN"; keep the legacy "Your ChatGPT code is NNNNNN" matcher; broaden fallbacks (incl. last-resort near-match).
- **IMAP search broadened** `"ChatGPT code"` → `"ChatGPT"` so new-format mail (different subject) is found.
- **Corrected endpoints:** `/api/v1/credentials/openai/oauth/browser/start` and `…/callback` (were `/api/ui/...` and `/auth/callback`).
- **Phone-required detection:** throw `Phone number required` instead of hanging.
- **Fail-fast:** `break` the account loop on unexpected failure.

## `scripts/debug-emails.cjs`
- Ad-hoc IMAP helper for inspecting verification emails.
- **Security:** removed a hardcoded Gmail address + app password; now reads `GMAIL_USER` / `GMAIL_APP_PASSWORD` (+ optional `IMAP_HOST`) from env and exits if unset.

## ⚠️ Action item (outside this repo)
The previously-hardcoded Gmail **app password was in plaintext on disk and must be revoked/rotated** in the Google account, regardless of this cleanup.

Card: `kanban/oauth-import-verification-2026.md`