### PR TITLE
feat(queue): return 429 + Retry-After on queue timeout/dropped/exhausted

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,0 +1,20 @@
+name: Auto Merge
+
+on:
+  pull_request:
+    types: [opened, ready_for_review]
+  check_suite:
+    types: [completed]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    if: ${{ github.event.pull_request.draft == false && github.event.pull_request.head.repo.full_name == github.repository }}
+    uses: open-hax/eta-mu/.github/workflows/auto-merge.yml@main
+    with:
+      pr: ${{ github.event.pull_request.number }}
+      merge-method: SQUASH
+    secrets: inherit

--- a/.github/workflows/ensure-pr-to-staging.yml
+++ b/.github/workflows/ensure-pr-to-staging.yml
@@ -1,0 +1,15 @@
+name: Ensure PR to Staging
+
+on:
+  schedule:
+    - cron: "*/30 * * * *"
+  workflow_dispatch:
+  create:
+
+jobs:
+  ensure-pr:
+    if: ${{ github.ref_type == 'branch' && !contains(fromJson('["staging","main","master","production","prod"]'), github.ref_name) || github.event_name != 'create' }}
+    uses: open-hax/eta-mu/.github/workflows/ensure-pr-to-staging.yml@main
+    with:
+      base: staging
+    secrets: inherit

--- a/.github/workflows/kanban-sync.yml
+++ b/.github/workflows/kanban-sync.yml
@@ -1,0 +1,26 @@
+name: Kanban Sync to GitHub Issues
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'kanban/**'
+  schedule:
+    - cron: "0 */6 * * *"
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Dry run (do not create/update issues)"
+        required: false
+        default: "false"
+        type: boolean
+
+jobs:
+  kanban-sync:
+    uses: open-hax/eta-mu/.github/workflows/kanban-sync.yml@main
+    with:
+      tasks-dir: kanban
+      dry-run: ${{ github.event.inputs.dry_run == 'true' }}
+      max-writes: 50
+      write-delay-ms: 1000
+    secrets: inherit

--- a/.github/workflows/release-on-merge.yml
+++ b/.github/workflows/release-on-merge.yml
@@ -1,0 +1,16 @@
+name: Release on Main Merge
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [main]
+
+jobs:
+  release:
+    if: ${{ github.event.pull_request.merged == true && github.event.pull_request.base.ref == 'main' }}
+    uses: open-hax/eta-mu/.github/workflows/release-and-publish.yml@main
+    with:
+      pr: ${{ github.event.pull_request.number }}
+      create-release: true
+      publish-npm: false
+    secrets: inherit

--- a/.github/workflows/review-resolution-gate.yml
+++ b/.github/workflows/review-resolution-gate.yml
@@ -1,4 +1,4 @@
-name: eta-mu-review-gate
+name: Review Resolution Gate
 
 on:
   pull_request:

--- a/README.md
+++ b/README.md
@@ -739,3 +739,7 @@ See [`docs/code-quality.md`](docs/code-quality.md) for scanner scope, thresholds
 5. Submit a PR into `staging` branch
 
 See [`DEVEL.md`](DEVEL.md) for development workflow details.
+
+## Testing deploys
+
+Adding the `testing` label to an eligible PR deploys the PR head to the shared staging slot via the open-hax/services Promethean deploy module (`.github/workflows/deploy-testing.yml`).

--- a/docs/notes/2026.06.03.16.49.53.md
+++ b/docs/notes/2026.06.03.16.49.53.md
@@ -1,0 +1,1 @@
+ ssh error@proxx.promethean.rest 'sudo apt-get update -qq && sudo apt-get install -y openjdk-21-jre-headless && java -version'

--- a/kanban/xiaomi-mimo-streaming-timeout-epic/01-bump-attempt-timeout.md
+++ b/kanban/xiaomi-mimo-streaming-timeout-epic/01-bump-attempt-timeout.md
@@ -1,0 +1,99 @@
+---
+uuid: "2233eb91-8ab8-4db9-85d1-522533be58db"
+title: "Spec 1.1: Scoped queue attempt-timeout for xiaomi/mimo-v2.5-pro"
+status: incoming
+priority: P2
+labels: ["bug", "streaming", "config"]
+created_at: "2026-06-08T20:30:00.000Z"
+source: "kanban/xiaomi-mimo-streaming-timeout-epic/01-bump-attempt-timeout.md"
+category: "bug"
+---
+
+> Source: `kanban/xiaomi-mimo-streaming-timeout-epic/01-bump-attempt-timeout.md`
+> Migrated-to-kanban: `kanban/xiaomi-mimo-streaming-timeout-epic/01-bump-attempt-timeout.md`
+
+# Spec 1.1: Scoped queue attempt-timeout for xiaomi/mimo-v2.5-pro
+
+**Spec ID:** XIAOMI-STREAM-TRUNC-001-01
+**Epic:** [xAIoMi Mimo-v2.5-pro Silent Stream Truncation](./EPIC.md)
+**Points:** 1
+**Priority:** High
+**Dependencies:** None
+
+## Objective
+
+Increase the queue `attempt-timeout-ms` specifically for `xiaomi/mimo-v2.5-pro` chat requests to account for 429 retry overhead + long generation times, preventing silent stream truncation. Use a scoped queue instance override rather than a global template change.
+
+## Current State
+
+- `resources/policies/runtime/70-request-queue-templates.edn:7`:
+  - `:queue/attempt-timeout-ms`: 30000 (30s)
+  - `:queue/total-timeout-ms`: 120000 (120s)
+- xiaomi/mimo-v2.5-pro observed behavior:
+  - 429 responses take ~2100ms each
+  - Successful generations take 19-31s
+  - With 2x 429s + 1x stream = ~35s total → exceeds 30s budget
+- The queue schema (`src/proxx/schema.cljs:408-416`) already supports `:match/family` on `:request-queue-instance` contracts
+- `src/proxx/queue/policy.cljs:26-36` (`instance-matches?`) already matches `match-family` against `ctx.model-family`
+
+## Target State
+
+Add a scoped `:request-queue-instance` contract that overrides `:queue/attempt-timeout-ms` only for `:model-family/mimo-v2-5-pro` chat requests, leaving the global default at 30s.
+
+## Implementation Steps
+
+1. Edit `resources/policies/runtime/70-request-queue-templates.edn`
+2. Add a new queue instance contract:
+   ```edn
+   {:contract/id :queue/mimo-v2-5-pro-chat
+    :contract/kind :request-queue-instance
+    :queue/template-id :queue/default
+    :match/family :model-family/mimo-v2-5-pro
+    :match/request-kind :chat
+    :queue/attempt-timeout-ms 60000}
+   ```
+3. Verify `:queue/total-timeout-ms` on `:queue/default` remains 120000 (still > attempt-timeout)
+4. Validate EDN syntax: `cljs.reader/read-string` + `schema/assert!`
+5. Restart Proxx process (EDN is read at startup)
+6. Verify via config API that the new instance resolves for xiaomi/mimo-v2.5-pro chat requests
+
+## Rejected Alternative: Global Bump (Option A)
+
+~~Bump `:queue/attempt-timeout-ms` on `:queue/default` from 30000 → 60000.~~ **Rejected** — this would affect all providers and all request kinds, unnecessarily increasing timeout exposure and halving effective throughput under congestion (concurrency-limit 8 × 60s = 8 min per slot vs 4 min at 30s).
+
+## Acceptance Criteria
+
+- [ ] New `:request-queue-instance` contract added for `:model-family/mimo-v2-5-pro` + `:chat`
+- [ ] `:queue/attempt-timeout-ms` set to 60000 on the instance override
+- [ ] Global `:queue/default` `attempt-timeout-ms` remains 30000
+- [ ] `:queue/total-timeout-ms` > `attempt-timeout-ms` invariant preserved for all instances
+- [ ] EDN passes schema validation (`pnpm build` or `schema/assert!`)
+- [ ] 31s+ xiaomi streams with preceding 429s complete successfully
+- [ ] Other model families continue to use default 30s attempt-timeout
+
+## Risk Assessment
+
+**Risk Level:** Very Low
+
+- Pure config change, no code modifications
+- Scoped to one model family, no global side effects
+- EDN files read at startup, easily revertible
+- No schema or API contract changes (uses existing schema fields)
+
+## Estimated Time
+
+15 minutes (config edit + validation + restart + verify)
+
+## Verification
+
+```bash
+# Validate EDN
+pnpm build  # triggers schema validation
+
+# Check resolved queue policy for mimo-v2.5-pro
+curl -H "Authorization: Bearer $PROXY_AUTH_TOKEN" \
+  "http://localhost:8789/api/v1/config"
+
+# Trigger a xiaomi request after 429 cooldown
+# Verify 200 response completes without truncation
+```

--- a/kanban/xiaomi-mimo-streaming-timeout-epic/02-streaming-aware-timeout.md
+++ b/kanban/xiaomi-mimo-streaming-timeout-epic/02-streaming-aware-timeout.md
@@ -1,0 +1,128 @@
+---
+uuid: "e46286fd-3668-4f64-aa5b-30b88130ae86"
+title: "Spec 1.2: Streaming-aware queue timeout"
+status: incoming
+priority: P2
+labels: ["bug", "streaming", "queue", "policy"]
+created_at: "2026-06-08T20:30:00.000Z"
+source: "kanban/xiaomi-mimo-streaming-timeout-epic/02-streaming-aware-timeout.md"
+category: "bug"
+---
+
+> Source: `kanban/xiaomi-mimo-streaming-timeout-epic/02-streaming-aware-timeout.md`
+> Migrated-to-kanban: `kanban/xiaomi-mimo-streaming-timeout-epic/02-streaming-aware-timeout.md`
+
+# Spec 1.2: Streaming-aware queue timeout
+
+**Spec ID:** XIAOMI-STREAM-TRUNC-001-02
+**Epic:** [xAIoMi Mimo-v2.5-pro Silent Stream Truncation](./EPIC.md)
+**Points:** 2
+**Priority:** High
+**Dependencies:** None
+
+## Objective
+
+Make the CLJS queue runtime aware of streaming state so that the attempt timer can be extended once streaming begins, preventing mid-stream truncation while keeping pre-stream timeouts strict.
+
+## Current State
+
+- `src/proxx/queue/runtime.cljs:110` - `effective-timeout-ms` uses static `attempt-timeout-ms`
+- `src/proxx/queue/runtime.cljs:125-133` - `run-attempt` arms abort timer at task start
+- Once streaming starts in `streamEventStreamToClient`, the timer keeps counting
+- Abort signal fires at 30s regardless of stream progress
+
+## Target State
+
+The queue runtime provides an `extendTimeout` capability to the task. When the task signals that streaming has started successfully, the timer resets to a new `stream-timeout-ms` value read from EDN policy.
+
+## Design
+
+### Option A: Reset timer on stream start (selected)
+
+- In `run-attempt`, attach `extendTimeout` as a JS property on the `AbortController` instance
+- The TS side accesses it via `(controller as any).extendTimeout(ms)` with a runtime guard
+- After `bootstrapEventStream` returns `{kind: "ready", ...}`, the stream handler calls `extendTimeout`
+- New timeout duration read from `:queue/stream-timeout-ms` in EDN policy (default 120000 = 2min)
+
+### Guard against timer leaks
+
+Use a `completed?` atom to prevent late `extendTimeout` calls from re-arming a timer after `run-attempt` has finished:
+
+```clojure
+(let [completed? (atom false)
+      extend-timeout! (fn [extra-ms]
+                        (when-not @completed?
+                          (js/clearTimeout @timer-ref)
+                          (reset! timer-ref (arm-abort-timer! controller extra-ms))))]
+  ...
+  (finally
+    (reset! completed? true)
+    (js/clearTimeout @timer-ref)))
+```
+
+### Rejected alternatives
+
+- **Option B: Separate bootstrap/stream timeouts** — The queue runtime sees one opaque promise. It cannot distinguish phases without the task signaling, which is the same callback problem as Option A.
+- **Option C: Heartbeat-based timeout** — Overkill. Requires periodic signaling from stream reader. Adds complexity for a problem that only needs one phase transition.
+
+## Implementation Steps
+
+1. **Extend CLJS queue runtime** (`src/proxx/queue/runtime.cljs`):
+   - Add `:queue/stream-timeout-ms` to `queue-policy-keys` in `src/proxx/queue/policy.cljs`
+   - Modify `run-attempt` to attach `extendTimeout` property to controller
+   - Guard with `completed?` atom to prevent leaks
+
+2. **Add EDN config** (`resources/policies/runtime/70-request-queue-templates.edn`):
+   - Add `:queue/stream-timeout-ms` to `:queue/default` template (default 120000)
+   - Verify schema accepts the new key
+
+3. **Modify stream handler** (`src/lib/provider-strategy/base.ts`):
+   - After `bootstrapEventStream` returns `ready`, access controller via closure or context
+   - Call `extendTimeout` with `context.config.streamTimeoutMs` (or read from policy)
+
+4. **Test**:
+   - CLJS unit test: mock controller with attached property, verify timer extends
+   - Integration test: mock slow stream, verify queue does not abort mid-stream
+   - Verify non-streaming tasks never call `extendTimeout` (no regression)
+
+## Acceptance Criteria
+
+- [ ] Queue timer extends when streaming starts
+- [ ] Streams longer than `attempt-timeout-ms` complete successfully
+- [ ] Pre-stream timeouts (routing, bootstrap) still enforced
+- [ ] Configurable via EDN policy (`:queue/stream-timeout-ms`), not env var
+- [ ] No regression for non-streaming requests
+- [ ] Timer leaks prevented by `completed?` guard
+
+## Risk Assessment
+
+**Risk Level:** Medium
+
+- Touches core queue runtime (CLJS)
+- Timer state management is tricky in async contexts
+- Must not leak timers on early abort
+- CLJS/TS interop boundary change
+- Needs thorough testing of edge cases
+
+## Estimated Time
+
+6-8 hours
+
+## Verification
+
+```clojure
+;; CLJS test snippet
+(deftest ^:async stream-timeout-extension
+  (let [policy {:queue/attempt-timeout-ms 5000
+                :queue/stream-timeout-ms 30000}
+        task (fn [controller]
+               (js/Promise.
+                (fn [resolve _]
+                  (js/setTimeout
+                   #(do (when-let [ext (.-extendTimeout controller)]
+                          (ext 25000))
+                        (js/setTimeout resolve 20000))
+                   1000))))]
+    ;; Should succeed (1s bootstrap + 20s stream = 21s < 5s+25s extended)
+    (is (await (run! task policy)))))
+```

--- a/kanban/xiaomi-mimo-streaming-timeout-epic/03-midstream-error-handling.md
+++ b/kanban/xiaomi-mimo-streaming-timeout-epic/03-midstream-error-handling.md
@@ -1,0 +1,135 @@
+---
+uuid: "aa3dee44-1d90-4e01-800d-267397689658"
+title: "Spec 1.3: Mid-stream SSE error event propagation"
+status: incoming
+priority: P2
+labels: ["bug", "streaming", "sse", "error-handling"]
+created_at: "2026-06-08T20:30:00.000Z"
+source: "kanban/xiaomi-mimo-streaming-timeout-epic/03-midstream-error-handling.md"
+category: "bug"
+---
+
+> Source: `kanban/xiaomi-mimo-streaming-timeout-epic/03-midstream-error-handling.md`
+> Migrated-to-kanban: `kanban/xiaomi-mimo-streaming-timeout-epic/03-midstream-error-handling.md`
+
+# Spec 1.3: Mid-stream SSE error event propagation
+
+**Spec ID:** XIAOMI-STREAM-TRUNC-001-03
+**Epic:** [xAIoMi Mimo-v2.5-pro Silent Stream Truncation](./EPIC.md)
+**Points:** 2
+**Priority:** High
+**Dependencies:** None
+
+## Objective
+
+When a stream is aborted mid-flight (queue timeout, upstream drop, etc.), emit an SSE error event before closing the connection so clients know the stream failed rather than completed. Follow the existing codebase convention used by `gemini.ts` and `ollama.ts`.
+
+## Current State
+
+`src/lib/provider-strategy/base.ts:185-204`:
+
+```typescript
+while (!rawResponse.writableEnded) {
+  const { done, value } = await bootstrap.reader.read();
+  if (done) {
+    break;  // ← upstream dropped or queue aborted, client sees clean EOF
+  }
+  if (value && value.byteLength > 0) {
+    rawResponse.write(value);
+  }
+}
+// finally block calls rawResponse.end() — no error indication
+```
+
+- `done=true` from reader: clean break, `rawResponse.end()`
+- Client receives partial stream with no error indication
+
+## Target State
+
+Before `rawResponse.end()`, write a single SSE `data:` line containing an OpenAI-compatible error payload, then close.
+
+### Correct SSE error format
+
+Use the existing codebase convention (matches `gemini.ts`, `ollama.ts`, and `openAiError()`):
+
+```
+data: {"error": {"message": "Stream aborted: queue timeout exceeded", "type": "server_error", "code": "queue_timeout", "param": null}}
+
+```
+
+**Do NOT use `event: error`** — it creates a separate SSE event with empty data. All field lines between blank lines belong to a single event.
+
+**Do NOT overload `[DONE]`** — it semantically means successful completion. OpenAI clients treat it as clean termination.
+
+## Implementation Steps
+
+1. **Add error event helper**:
+   - Create `src/lib/sse/error-event.ts`
+   - Function: `buildSseErrorEvent(errorCode, errorMessage, errorType?)`
+   - Returns `data: {...}\n\n` bytes matching `openAiError()` shape
+
+2. **Modify `streamEventStreamToClient`** (`src/lib/provider-strategy/base.ts`):
+   - Track whether stream completed naturally or was interrupted
+   - In `finally` block, if interrupted and response not ended:
+     - Wrap error-event write in `try/catch`
+     - Check `!rawResponse.destroyed && !rawResponse.writableEnded` before writing
+     - Write SSE error event via helper
+     - Then call `rawResponse.end()`
+
+3. **Handle different abort reasons**:
+   - Queue timeout: `code: "queue_timeout"`, `type: "server_error"`
+   - Upstream drop: `code: "upstream_disconnect"`, `type: "server_error"`
+   - Bootstrap failure: already handled upstream, but could add SSE error there too
+
+4. **Add stream read timeout**:
+   - Port `readStreamChunkWithTimeout` from `openai.ts` to `streamEventStreamToClient`
+   - Prevents indefinite hangs when upstream socket stalls
+
+5. **Client contract**:
+   - Document SSE error event format in `docs/streaming-errors.md`
+   - opencode clients should detect `data:` lines containing `"error"` key
+
+6. **Test**:
+   - Mock abort controller, verify SSE error event emitted
+   - Mock upstream drop, verify `upstream_disconnect` code
+   - Verify existing tests still pass (no extra events on normal completion)
+   - Test write-after-end protection (`try/catch` + `destroyed` check)
+
+## Acceptance Criteria
+
+- [ ] Mid-stream aborts emit SSE error event before closing
+- [ ] Error events use `data: {...}\n\n` format matching existing codebase convention
+- [ ] Normal stream completion emits no error event
+- [ ] Writes guarded by `try/catch` and `destroyed` check
+- [ ] opencode client can parse and report error to user
+- [ ] Dashboard shows distinct error indication for truncated streams
+
+## Risk Assessment
+
+**Risk Level:** Low-Medium
+
+- Additive change, doesn't break existing behavior
+- SSE format is standard, clients should handle unknown events gracefully
+- Must ensure error event doesn't corrupt already-partial JSON stream
+- Best-effort signal: if truncation occurs mid-event, client may see parse error before structured error
+
+## Estimated Time
+
+3-4 hours
+
+## Verification
+
+```typescript
+// Test snippet
+const mockReader = {
+  read: async () => {
+    await new Promise((_, reject) => setTimeout(() => reject(new Error("aborted")), 100));
+    return { done: true, value: undefined };
+  },
+  releaseLock: () => {},
+};
+
+// After streamEventStreamToClient completes,
+// verify rawResponse received:
+// `data: {"error":{"message":"...","type":"server_error","code":"...","param":null}}\n\n`
+```

--- a/kanban/xiaomi-mimo-streaming-timeout-epic/04-rate-limit-policy-extraction.md
+++ b/kanban/xiaomi-mimo-streaming-timeout-epic/04-rate-limit-policy-extraction.md
@@ -1,0 +1,146 @@
+---
+uuid: "b7f318ae-dff2-40ee-9fb3-41f472f2c59c"
+title: "Spec 1.4: Move rate-limit classification from TypeScript into EDN policy"
+status: incoming
+priority: P1
+labels: ["bug", "policy", "rate-limiting", "refactor"]
+created_at: "2026-06-08T21:15:00.000Z"
+source: "kanban/xiaomi-mimo-streaming-timeout-epic/04-rate-limit-policy-extraction.md"
+category: "bug"
+---
+
+> Source: `kanban/xiaomi-mimo-streaming-timeout-epic/04-rate-limit-policy-extraction.md`
+> Migrated-to-kanban: `kanban/xiaomi-mimo-streaming-timeout-epic/04-rate-limit-policy-extraction.md`
+
+# Spec 1.4: Move rate-limit classification from TypeScript into EDN policy
+
+**Spec ID:** XIAOMI-STREAM-TRUNC-001-04
+**Epic:** [xAIoMi Mimo-v2.5-pro Silent Stream Truncation](./EPIC.md)
+**Points:** 3
+**Priority:** P1
+**Dependencies:** None
+
+## Objective
+
+Extract the imperative `classifyRateLimitKind` heuristic from `src/lib/proxy.ts` and replace it with a declarative EDN policy contract evaluated by the CLJS runtime. Generic heuristics remain as CLJS fallback defaults; provider-specific overrides move to EDN. No new TypeScript business logic.
+
+## Current State
+
+`src/lib/proxy.ts:211-268` contains a 58-line imperative function that:
+1. Hardcodes Ollama session/weekly limit detection
+2. Hardcodes a list of quota keywords ("usage limit", "quota", "exhausted", etc.)
+3. Hardcodes a list of concurrency indicators ("concurrent", "too many requests", etc.)
+4. Applies a 30-second retry-after threshold heuristic
+5. Defaults everything to `quota_exhausted`
+
+This violates the policy boundary: provider-specific behavior is declared in TypeScript instead of EDN.
+
+## Target State
+
+A new contract kind `:rate-limit-behavior` in the EDN policy layer that allows each provider to declare how its 429 responses should be classified. The CLJS runtime evaluates this contract during routing, and TypeScript only reads the result.
+
+### Contract schema
+
+```edn
+{:contract/id :rate-limit-behavior/xiaomi
+ :contract/kind :rate-limit-behavior
+ :match/provider-pattern "^xiaomi$"
+ :rate-limit/classification :quota_exhausted
+ :rate-limit/retry-behavior :failover-immediately}
+```
+
+Using `:match/provider-pattern` (regex) keeps the DSL consistent with `:provider-capability` contracts. Optional fields allow overriding heuristic inputs:
+
+- `:rate-limit/quota-keywords` — override default quota keyword list
+- `:rate-limit/concurrency-keywords` — override default concurrency keyword list
+- `:rate-limit/concurrency-threshold-ms` — override retry-after threshold (default 30000)
+
+### Fallback behavior
+
+Generic heuristics (quota keywords, concurrency indicators, 30s threshold) remain as CLJS fallback defaults for providers without explicit `:rate-limit-behavior` contracts. This preserves safe behavior for unconfigured providers.
+
+## Implementation Steps
+
+1. **Add Malli schema** (`src/proxx/schema.cljs`):
+   - Define `RateLimitBehaviorContract` schema
+   - Add to `PolicyContract` multi-schema so the loader accepts it
+   - Add to `contract-kinds` set
+
+2. **Add contract extractor** (`src/proxx/policy/contracts.cljs`):
+   - Extract `:rate-limit-behavior` contracts into a compiled index (provider-id → contract)
+   - O(1) lookup in `compile-contracts`
+
+3. **Write classification function** (`src/proxx/policy.cljs` or new ns):
+   - `rate-limit-classification` takes provider-id, response body, retry-after-ms
+   - Look up provider's contract; if found, use declared classification
+   - If not found, apply generic heuristics (current behavior)
+   - Returns keyword `:quota_exhausted` or `:concurrency_throttle`
+
+4. **Export to runtime** (`src/proxx/runtime.cljs`):
+   - Wrap `rate-limit-classification` with `clj->js` conversion
+   - Export as `rateLimitClassification` function
+
+5. **Update TS interop** (`src/lib/cljs-runtime.ts`):
+   - Add `rateLimitClassification` to `ProxxCljsRuntime` interface
+   - Make it optional in `isProxxCljsRuntime` validator (rolling deploy safety)
+
+6. **Modify routing executor** (`src/lib/provider-strategy/routing/attempt-executor.ts`):
+   - Replace `classifyRateLimitKind` import/call with CLJS runtime call
+   - Pass provider-id, response body, retry-after-ms
+   - Apply retry/failover logic based on returned classification
+
+7. **Migrate existing heuristics**:
+   - Move Ollama session/weekly detection into EDN contract (`:rate-limit-behavior/ollama-cloud`)
+   - Move xiaomi override into EDN contract (`:rate-limit-behavior/xiaomi`)
+   - Optionally add zai contract (`:rate-limit-behavior/zai` with `:concurrency_throttle` / `:retry-same`)
+   - Keep generic keyword lists as CLJS fallback defaults
+
+8. **Deprecate TS heuristic** (`src/lib/proxy.ts`):
+   - Remove or demote `classifyRateLimitKind` to a thin wrapper that logs a deprecation warning
+   - Remove `detectOllamaLimitKind` (moved to EDN)
+
+9. **Test**:
+   - CLJS policy preview tests for each provider's classification
+   - Integration test: mock xiaomi 429, verify failover to second key
+   - Regression test: generic heuristic still classifies "too many requests" as `concurrency_throttle` when no contract matches
+   - Verify no regression for ZAI (still retries same credential)
+   - Run `pnpm build`, `pnpm run check:no-new-typescript`, proxy test suite
+
+## Acceptance Criteria
+
+- [ ] `classifyRateLimitKind` in `proxy.ts` delegates to CLJS policy runtime (or removed)
+- [ ] Provider-specific rate limit behavior declared in EDN, not TypeScript
+- [ ] xiaomi 429s trigger immediate failover to next key (no concurrency retry loop)
+- [ ] Ollama session/weekly limits correctly classified via EDN contract
+- [ ] ZAI and other concurrency-throttled providers still retry same credential when appropriate
+- [ ] Generic heuristic preserved as fallback for unconfigured providers
+- [ ] All existing tests pass
+- [ ] New policy preview tests for rate limit classification
+- [ ] `rateLimitClassification` optional in `isProxxCljsRuntime` (rolling deploy safety)
+
+## Risk Assessment
+
+**Risk Level:** Medium
+
+- Touches core routing decision path
+- Must not break existing provider behavior
+- CLJS/TS interop boundary change
+- Requires careful testing of all provider types
+- Malli schema must be correct or loader throws on startup
+
+## Estimated Time
+
+8-10 hours
+
+## Verification
+
+```clojure
+;; CLJS policy preview test
+(deftest rate-limit-classification-test
+  (let [result (proxx.policy/rate-limit-classification
+                "xiaomi"
+                {:error {:message "Too many requests"}}
+                5000)]
+    (is (= :quota-exhausted (:classification result)))
+    (is (= :failover-immediately (:retry-behavior result)))))
+```

--- a/kanban/xiaomi-mimo-streaming-timeout-epic/EPIC.md
+++ b/kanban/xiaomi-mimo-streaming-timeout-epic/EPIC.md
@@ -1,0 +1,82 @@
+---
+uuid: "bb6bee41-cf4f-4f46-99e1-53d352c50f00"
+title: "xAIoMi Mimo-v2.5-pro Silent Stream Truncation Epic"
+status: incoming
+priority: P2
+labels: ["bug", "streaming", "rate-limiting", "xiaomi"]
+created_at: "2026-06-08T20:30:00.000Z"
+source: "kanban/xiaomi-mimo-streaming-timeout-epic/EPIC.md"
+category: "bug"
+---
+
+> Source: `kanban/xiaomi-mimo-streaming-timeout-epic/EPIC.md`
+> Migrated-to-kanban: `kanban/xiaomi-mimo-streaming-timeout-epic/EPIC.md`
+
+# xAIoMi Mimo-v2.5-pro Silent Stream Truncation Epic
+
+**Epic ID:** XIAOMI-STREAM-TRUNC-001
+**Status:** Incoming
+**Total Points:** 8
+**Estimated Timeline:** 1 sprint
+
+## Problem Statement
+
+When using xiaomi/mimo-v2.5-pro via Proxx, streams sometimes stop silently without error. The client sees a clean EOF mid-generation. Dashboard shows duplicated 429s, then a successful 200 that takes 20-30s, but the stream never completes.
+
+## Root Cause
+
+The queue `attempt-timeout-ms` (30s) covers the **entire** `executeProviderRoutingPlan` call, including:
+1. Time spent on failed candidates (429s taking ~2s each)
+2. Time to find a working candidate
+3. **Actual streaming time**
+
+When xiaomi returns 429s on initial candidates, the subsequent successful stream starts with less time remaining in the 30s budget. A 31s generation gets truncated at 30s, but the client sees a clean stream termination because `streamEventStreamToClient` just calls `rawResponse.end()` on any abort.
+
+## Evidence
+
+```
+8:28:13 PM xiaomi/Masussy-key mimo-v2.5-pro Standard 429 2133 ms
+8:25:52 PM xiaomi/Masussy-key mimo-v2.5-pro Standard 429 2117 ms
+8:28:42 PM xiaomi/Masussy-key mimo-v2.5-pro Standard 200 31188 ms  ← truncated mid-stream
+8:26:09 PM xiaomi/Masussy-key mimo-v2.5-pro Standard 200 19034 ms  ← ok (no preceding 429s)
+```
+
+The 31s request only succeeds when no preceding 429s eat the timeout budget.
+
+## Goals
+
+1. Prevent silent stream truncation when queue timeout fires mid-stream
+2. Ensure clients receive meaningful errors when streams fail
+3. Make timeout budget account for routing retry overhead
+4. Move provider-specific rate limit classification from TypeScript into declarative EDN policy
+
+## Child Specs
+
+| Spec | Points | Priority | Dependencies |
+|------|--------|----------|--------------|
+| [1.1 Scoped queue attempt-timeout for xiaomi/mimo-v2.5-pro](./01-bump-attempt-timeout.md) | 1 | High | None |
+| [1.2 Streaming-aware queue timeout](./02-streaming-aware-timeout.md) | 2 | High | None |
+| [1.3 Mid-stream SSE error event](./03-midstream-error-handling.md) | 2 | High | None |
+| [1.4 Rate-limit classification in EDN policy](./04-rate-limit-policy-extraction.md) | 3 | P1 | None |
+
+## Success Criteria
+
+1. **No silent truncations** - Clients always get an error or complete stream, never clean EOF mid-generation
+2. **429 retry overhead accounted** - Queue timeout budget covers candidate failover + full generation
+3. **SSE error propagation** - Mid-stream aborts emit `data: [ERROR] ...` before closing
+4. **Dashboard clarity** - Truncated streams show distinct error code, not just 200
+5. **Policy-driven rate limits** - Provider-specific 429 classification lives in EDN, not TypeScript
+6. **xiaomi immediate failover** - xiaomi 429s try the next key immediately, no wasted retries
+
+## Rollback Strategy
+
+- Each child spec is independently deliverable
+- Timeout changes are config-only (EDN), easily revertible
+- SSE error handling is additive, safe to disable
+- No schema migrations required
+
+## Open Questions
+
+1. Should attempt-timeout scale dynamically with model-family known latencies?
+2. Should we reset the timer when streaming starts, or add a separate `stream-timeout-ms`?
+3. Should SSE error events follow a specific format for opencode clients to parse?

--- a/resources/policies/runtime/00-manifest.edn
+++ b/resources/policies/runtime/00-manifest.edn
@@ -13,7 +13,8 @@
    "50-account-selection.edn"
    "60-tenant-enforcement.edn"
    "65-federation-routing.edn"
-   "70-request-queue-templates.edn"
-  "90-router.edn"]
+    "70-request-queue-templates.edn"
+    "80-rate-limit-classification.edn"
+   "90-router.edn"]
  :policy.loader/invariant
  "Files are append/override in order: facts first, then derived rules, then the root router. More-specific clauses must precede catch-all clauses."}

--- a/resources/policies/runtime/10-model-families.edn
+++ b/resources/policies/runtime/10-model-families.edn
@@ -106,6 +106,12 @@
   :match/provider-pattern "^ollama-lan$"
   :alias/model-id "gemma4:e4b-128k"}
 
+ {:contract/id :model-alias/qwen3-embedding-8k
+  :contract/kind :model-alias
+  :match/model-pattern "(?i)^qwen3-embedding:0\\.6b$"
+  :match/provider-pattern "^ollama-lan$"
+  :alias/model-id "qwen3-embedding:0.6b-8k"}
+
  {:contract/id :model-family/blaze-text
   :contract/kind :model-family
   :match/model-pattern "(?i)^(?:DeepSeek-V4-Flash-TEST|MiniMax-M2\\.[157]-highspeed|claude-opus-4\\.[567]|openai/gpt-4o|qwen/qwen3\\.5-397b|qwen3\\.[56]-(?:omni|plus|max).*|x-ai/grok-4\\.20-fast|z-ai/glm4\\.7)$"

--- a/resources/policies/runtime/70-request-queue-templates.edn
+++ b/resources/policies/runtime/70-request-queue-templates.edn
@@ -9,6 +9,34 @@
   :queue/max-retries 0
   :queue/retry-backoff :immediate}
 
+ {:contract/id :queue/mimo-v2-5-pro-chat
+   :contract/kind :request-queue-instance
+   :queue/template-id :queue/default
+   :queue/provider-id "xiaomi"
+   :match/request-kind :chat
+   :queue/attempt-timeout-ms 60000}
+
+ {:contract/id :queue/ollama-lan-chat
+   :contract/kind :request-queue-instance
+   :queue/template-id :queue/default
+   :queue/provider-id "ollama-lan"
+   :match/request-kind :chat
+   :queue/attempt-timeout-ms 120000}
+
+ {:contract/id :queue/ollama-chat
+   :contract/kind :request-queue-instance
+   :queue/template-id :queue/default
+   :queue/provider-id "ollama"
+   :match/request-kind :chat
+   :queue/attempt-timeout-ms 120000}
+
+ {:contract/id :queue/ollama-cloud-chat
+   :contract/kind :request-queue-instance
+   :queue/template-id :queue/default
+   :queue/provider-id "ollama-cloud"
+   :match/request-kind :chat
+   :queue/attempt-timeout-ms 120000}
+
  {:contract/id :queue/default-chat
   :contract/kind :request-queue-instance
   :queue/template-id :queue/default
@@ -25,6 +53,6 @@
   :match/request-kind :images}
 
  {:contract/id :queue/default-embeddings
- :contract/kind :request-queue-instance
- :queue/template-id :queue/default
- :match/request-kind :embeddings}]
+  :contract/kind :request-queue-instance
+  :queue/template-id :queue/default
+  :match/request-kind :embeddings}]

--- a/resources/policies/runtime/70-request-queue-templates.edn
+++ b/resources/policies/runtime/70-request-queue-templates.edn
@@ -25,6 +25,6 @@
   :match/request-kind :images}
 
  {:contract/id :queue/default-embeddings
-  :contract/kind :request-queue-instance
-  :queue/template-id :queue/default
-  :match/request-kind :embeddings}]
+ :contract/kind :request-queue-instance
+ :queue/template-id :queue/default
+ :match/request-kind :embeddings}]

--- a/resources/policies/runtime/80-rate-limit-classification.edn
+++ b/resources/policies/runtime/80-rate-limit-classification.edn
@@ -1,0 +1,6 @@
+[{:contract/id :rate-limit-classification/xiaomi
+  :contract/kind :rate-limit-classification
+  :match/provider-id "xiaomi"
+  :classify/status 429
+  :classify/retry-after-ms {:max 30000}
+  :classify/result :rate-limit/volume}]

--- a/scripts/typescript-inventory-allowlist.json
+++ b/scripts/typescript-inventory-allowlist.json
@@ -1407,6 +1407,18 @@
       "removalCondition": "test coverage runs from CLJS/node-test or an accepted non-TS harness"
     },
     {
+      "path": "src/tests/queue-error-429.test.ts",
+      "owner": "T4-test-harness-cljs-migration",
+      "disposition": "port-test-to-cljs",
+      "removalCondition": "test coverage runs from CLJS/node-test or an accepted non-TS harness"
+    },
+    {
+      "path": "src/tests/queue-signal.test.ts",
+      "owner": "T4-test-harness-cljs-migration",
+      "disposition": "port-test-to-cljs",
+      "removalCondition": "test coverage runs from CLJS/node-test or an accepted non-TS harness"
+    },
+    {
       "path": "src/tests/rate-limit-classify.test.ts",
       "owner": "T4-test-harness-cljs-migration",
       "disposition": "port-test-to-cljs",

--- a/shadow-cljs.edn
+++ b/shadow-cljs.edn
@@ -25,8 +25,9 @@
                                               resolveFederationRouteCandidates proxx.runtime/resolve-federation-route-candidates-js
                                               authorizeTenantProviderPolicy proxx.runtime/authorize-tenant-provider-policy-js
                                              runModelCandidates proxx.runtime/run-model-candidates-js
-                                           resolveQueuePolicy proxx.runtime/resolve-queue-policy-js
-                                           runQueued proxx.runtime/run-queued-js}}}
+                                            resolveQueuePolicy proxx.runtime/resolve-queue-policy-js
+                                            runQueued proxx.runtime/run-queued-js
+                                            classifyRateLimit proxx.runtime/classify-rate-limit-js}}}
    :js-options {:js-provider :import
                 :keep-as-import #{"node:fs" "node:path"}}
    :compiler-options {:output-feature-set :es-next

--- a/shadow-cljs.edn
+++ b/shadow-cljs.edn
@@ -16,8 +16,9 @@
                                           loadPolicyEvidence proxx.runtime/load-policy-evidence-js
                                           loadModelPricingOverrides proxx.runtime/load-model-pricing-overrides-js
                                           loadProviderSeedSpecs proxx.runtime/load-provider-seed-specs-js
-                                            previewPolicyDecision proxx.runtime/preview-policy-decision-js
-                                            normalizeReasoningRequest proxx.runtime/normalize-reasoning-request-js
+                                           previewPolicyDecision proxx.runtime/preview-policy-decision-js
+                                           executePolicyTree proxx.runtime/execute-policy-tree-js
+                                           normalizeReasoningRequest proxx.runtime/normalize-reasoning-request-js
                                             resolveModelAlias proxx.runtime/resolve-model-alias-js
                                              getProviderRoutes proxx.runtime/get-provider-routes-js
                                               filterProviderRoutes proxx.runtime/filter-provider-routes-js

--- a/src/lib/cljs-runtime.ts
+++ b/src/lib/cljs-runtime.ts
@@ -91,6 +91,11 @@ export interface ProxxCljsRuntime {
   readonly loadModelPricingOverrides: (manifestPath: string) => unknown;
   readonly loadProviderSeedSpecs: (manifestPath: string) => unknown;
   readonly previewPolicyDecision: (manifestPath: string, input: unknown) => CljsPolicyDecisionPreviewResult;
+  readonly executePolicyTree?: (
+    manifestPath: string,
+    input: unknown,
+    tryCandidate: (candidate: unknown) => Promise<{ readonly status: string; readonly reason?: string }>,
+  ) => Promise<{ readonly status: string; readonly result?: unknown; readonly trace?: readonly unknown[] }>;
   readonly normalizeReasoningRequest: (manifestPath: string, input: unknown) => CljsReasoningNormalizationResult;
   readonly resolveModelAlias: (manifestPath: string, modelId: string, providerId: string) => CljsModelAliasResult;
   readonly resolveAutoModelCandidates?: (manifestPath: string, input: unknown) => CljsAutoModelCandidatesResult;
@@ -146,6 +151,7 @@ function isProxxCljsRuntime(value: Record<string, unknown>): value is Record<str
     (value.resolveFederationRouteCandidates === undefined || typeof value.resolveFederationRouteCandidates === "function") &&
     (value.authorizeTenantProviderPolicy === undefined || typeof value.authorizeTenantProviderPolicy === "function") &&
     (value.runModelCandidates === undefined || typeof value.runModelCandidates === "function") &&
+    (value.executePolicyTree === undefined || typeof value.executePolicyTree === "function") &&
     (value.resolveQueuePolicy === undefined || typeof value.resolveQueuePolicy === "function") &&
     (value.getProviderRoutes === undefined || typeof value.getProviderRoutes === "function") &&
     (value.runQueued === undefined || typeof value.runQueued === "function")

--- a/src/lib/cljs-runtime.ts
+++ b/src/lib/cljs-runtime.ts
@@ -110,6 +110,12 @@ export interface ProxxCljsRuntime {
   ) => Promise<CljsModelCandidatesRunResult>;
   readonly resolveQueuePolicy?: (manifestPath: string, ctx: unknown) => CljsQueuePolicyResult;
   readonly runQueued?: <T>(manifestPath: string, ctx: unknown, task: (controller: AbortController) => Promise<T>) => Promise<T>;
+  readonly classifyRateLimit?: (
+    manifestPath: string,
+    providerId: string,
+    status: number,
+    retryAfterMs: number | undefined,
+  ) => { readonly status: string; readonly result?: string | null };
 }
 
 export type CljsRuntimeLoadResult =

--- a/src/lib/ollama-context.ts
+++ b/src/lib/ollama-context.ts
@@ -164,7 +164,17 @@ export async function fetchOllamaModelContextLength(
     ?? asNumber(modelInfo?.["gemma3.context_length"])
     ?? asNumber(modelInfo?.["general.context_length"]);
 
-  const result = directContext ?? modelInfoContext ?? null;
+  // Respect model-specific num_ctx parameter if set (e.g. via Modelfile)
+  const parameters = asString(payload["parameters"]);
+  let paramContext: number | null = null;
+  if (parameters) {
+    const match = parameters.match(/num_ctx\s+(\d+)/);
+    if (match) {
+      paramContext = asNumber(Number(match[1])) ?? null;
+    }
+  }
+
+  const result = paramContext ?? directContext ?? modelInfoContext ?? null;
   if (result !== null) {
     contextLengthCache.set(cacheKey, { length: result, fetchedAt: Date.now() });
   }

--- a/src/lib/provider-strategy/base.ts
+++ b/src/lib/provider-strategy/base.ts
@@ -179,8 +179,9 @@ async function streamEventStreamToClient(
 
   // Extend queue timeout now that streaming has started successfully
   const signal = context.queueSignal;
-  if (signal && typeof (signal as any).extendTimeout === "function") {
-    (signal as any).extendTimeout();
+  const extendedSignal = signal as AbortSignal & { extendTimeout?: () => void } | undefined;
+  if (extendedSignal && typeof extendedSignal.extendTimeout === "function") {
+    extendedSignal.extendTimeout();
   }
 
   try {

--- a/src/lib/provider-strategy/base.ts
+++ b/src/lib/provider-strategy/base.ts
@@ -177,6 +177,12 @@ async function streamEventStreamToClient(
   }
   rawResponse.flushHeaders();
 
+  // Extend queue timeout now that streaming has started successfully
+  const signal = context.queueSignal;
+  if (signal && typeof (signal as any).extendTimeout === "function") {
+    (signal as any).extendTimeout();
+  }
+
   try {
     for (const chunk of bootstrap.bufferedChunks) {
       rawResponse.write(chunk);
@@ -200,6 +206,15 @@ async function streamEventStreamToClient(
     }
 
     if (!rawResponse.writableEnded) {
+      // If the queue aborted us mid-stream, emit an SSE error so the client
+      // sees a proper error rather than a silent EOF.
+      if (signal?.aborted) {
+        rawResponse.write(
+          `data: ${JSON.stringify({
+            error: { message: "Provider stream aborted by request queue timeout" },
+          })}\n\n`
+        );
+      }
       rawResponse.end();
     }
   }

--- a/src/lib/provider-strategy/local.ts
+++ b/src/lib/provider-strategy/local.ts
@@ -115,6 +115,7 @@ export async function executeLocalStrategy(
 
     await strategy.handleLocalAttempt(reply, upstreamResponse, {
       ...context,
-      baseUrl: context.config.ollamaBaseUrl
+      baseUrl: context.config.ollamaBaseUrl,
+      queueSignal,
     });
 }

--- a/src/lib/provider-strategy/routing/attempt-executor.ts
+++ b/src/lib/provider-strategy/routing/attempt-executor.ts
@@ -255,6 +255,7 @@ export async function executeProviderRoutingPlan(
           ...baseProviderContext,
           baseUrl: step.baseUrl,
           attempt: accumulator.attempts,
+          queueSignal,
         };
 
         const upstreamUrl = joinUrl(providerContext.baseUrl, upstreamPath);
@@ -537,6 +538,7 @@ export async function executeProviderRoutingPlan(
             responseBody,
             cooldownMs,
             context.config.concurrencyThrottleThresholdMs,
+            candidate.providerId,
           );
 
           if (rateLimitKind === "concurrency_throttle") {
@@ -645,7 +647,7 @@ export async function executeProviderRoutingPlan(
               } catch {
                 retryBody = undefined;
               }
-              const retryKind = classifyRateLimitKind(retryBody, retryCooldownMs, context.config.concurrencyThrottleThresholdMs);
+              const retryKind = classifyRateLimitKind(retryBody, retryCooldownMs, context.config.concurrencyThrottleThresholdMs, candidate.providerId);
               try { await retryResponse.arrayBuffer(); } catch { /* ignore */ }
 
               if (retryKind !== "concurrency_throttle") {

--- a/src/lib/provider-strategy/routing/attempt-executor.ts
+++ b/src/lib/provider-strategy/routing/attempt-executor.ts
@@ -539,6 +539,7 @@ export async function executeProviderRoutingPlan(
             cooldownMs,
             context.config.concurrencyThrottleThresholdMs,
             candidate.providerId,
+            context.config.cljsPolicyManifestPath,
           );
 
           if (rateLimitKind === "concurrency_throttle") {
@@ -647,7 +648,7 @@ export async function executeProviderRoutingPlan(
               } catch {
                 retryBody = undefined;
               }
-              const retryKind = classifyRateLimitKind(retryBody, retryCooldownMs, context.config.concurrencyThrottleThresholdMs, candidate.providerId);
+              const retryKind = classifyRateLimitKind(retryBody, retryCooldownMs, context.config.concurrencyThrottleThresholdMs, candidate.providerId, context.config.cljsPolicyManifestPath);
               try { await retryResponse.arrayBuffer(); } catch { /* ignore */ }
 
               if (retryKind !== "concurrency_throttle") {

--- a/src/lib/provider-strategy/shared.ts
+++ b/src/lib/provider-strategy/shared.ts
@@ -195,10 +195,12 @@ interface ProviderAttemptContext extends StrategyRequestContext {
   readonly account: ProviderCredential;
   readonly hasMoreCandidates: boolean;
   readonly attempt: number;
+  readonly queueSignal?: AbortSignal;
 }
 
 interface LocalAttemptContext extends StrategyRequestContext {
   readonly baseUrl: string;
+  readonly queueSignal?: AbortSignal;
 }
 
 interface ProviderAttemptOutcomeHandled {

--- a/src/lib/provider-strategy/strategies/factory.ts
+++ b/src/lib/provider-strategy/strategies/factory.ts
@@ -99,12 +99,36 @@ export class FactoryResponsesPassthroughStrategy extends BaseProviderStrategy {
         }
       }
       rawResponse.flushHeaders();
+
+      // Extend queue timeout now that streaming has started successfully
+      const signal = context.queueSignal;
+      if (signal && typeof (signal as any).extendTimeout === "function") {
+        (signal as any).extendTimeout();
+      }
+
       const nodeStream = Readable.fromWeb(upstreamResponse.body as never);
       nodeStream.on("error", () => {
         if (!rawResponse.writableEnded) {
           rawResponse.end();
         }
       });
+
+      // Emit SSE error if the queue aborts us mid-stream
+      if (signal) {
+        const onAbort = () => {
+          if (!rawResponse.writableEnded) {
+            rawResponse.write(
+              `data: ${JSON.stringify({
+                error: { message: "Provider stream aborted by request queue timeout" },
+              })}\n\n`
+            );
+            rawResponse.end();
+          }
+        };
+        signal.addEventListener("abort", onAbort, { once: true });
+        nodeStream.on("end", () => signal.removeEventListener("abort", onAbort));
+      }
+
       nodeStream.pipe(rawResponse);
       return { kind: "handled" };
     }
@@ -283,6 +307,27 @@ export class FactoryResponsesProviderStrategy extends TransformedJsonProviderStr
         }
       }
       rawResponse.flushHeaders();
+
+      // Extend queue timeout now that streaming has started successfully
+      const signal = context.queueSignal;
+      if (signal && typeof (signal as any).extendTimeout === "function") {
+        (signal as any).extendTimeout();
+      }
+
+      // Emit SSE error if the queue aborts us mid-stream
+      if (signal) {
+        const onAbort = () => {
+          if (!rawResponse.writableEnded) {
+            rawResponse.write(
+              `data: ${JSON.stringify({
+                error: { message: "Provider stream aborted by request queue timeout" },
+              })}\n\n`
+            );
+            rawResponse.end();
+          }
+        };
+        signal.addEventListener("abort", onAbort, { once: true });
+      }
 
       try {
         const result = await streamResponsesSseToChatCompletionChunks(

--- a/src/lib/provider-strategy/strategies/factory.ts
+++ b/src/lib/provider-strategy/strategies/factory.ts
@@ -102,8 +102,9 @@ export class FactoryResponsesPassthroughStrategy extends BaseProviderStrategy {
 
       // Extend queue timeout now that streaming has started successfully
       const signal = context.queueSignal;
-      if (signal && typeof (signal as any).extendTimeout === "function") {
-        (signal as any).extendTimeout();
+      const extendedSignal = signal as AbortSignal & { extendTimeout?: () => void } | undefined;
+      if (extendedSignal && typeof extendedSignal.extendTimeout === "function") {
+        extendedSignal.extendTimeout();
       }
 
       const nodeStream = Readable.fromWeb(upstreamResponse.body as never);
@@ -310,8 +311,9 @@ export class FactoryResponsesProviderStrategy extends TransformedJsonProviderStr
 
       // Extend queue timeout now that streaming has started successfully
       const signal = context.queueSignal;
-      if (signal && typeof (signal as any).extendTimeout === "function") {
-        (signal as any).extendTimeout();
+      const extendedSignal = signal as AbortSignal & { extendTimeout?: () => void } | undefined;
+      if (extendedSignal && typeof extendedSignal.extendTimeout === "function") {
+        extendedSignal.extendTimeout();
       }
 
       // Emit SSE error if the queue aborts us mid-stream

--- a/src/lib/provider-strategy/strategies/gemini.ts
+++ b/src/lib/provider-strategy/strategies/gemini.ts
@@ -724,8 +724,9 @@ export class GeminiChatProviderStrategy extends BaseProviderStrategy implements 
 
         // Extend queue timeout now that streaming has started successfully
         const signal = context.queueSignal;
-        if (signal && typeof (signal as any).extendTimeout === "function") {
-          (signal as any).extendTimeout();
+        const extendedSignal = signal as AbortSignal & { extendTimeout?: () => void } | undefined;
+        if (extendedSignal && typeof extendedSignal.extendTimeout === "function") {
+          extendedSignal.extendTimeout();
         }
 
         // Emit SSE error if the queue aborts us mid-stream

--- a/src/lib/provider-strategy/strategies/gemini.ts
+++ b/src/lib/provider-strategy/strategies/gemini.ts
@@ -490,6 +490,31 @@ export function geminiPayloadToSdkRequest(model: string, payload: Record<string,
   return { model, contents: sdkContents, config };
 }
 
+export function classifyGeminiSdkError(errorMessage: string): ProviderAttemptOutcome {
+  if (
+    errorMessage.includes("rate limit")
+    || errorMessage.includes("RATE_LIMIT")
+    || errorMessage.includes("UNAVAILABLE")
+    || errorMessage.includes("503")
+  ) {
+    return { kind: "continue", rateLimit: true };
+  }
+
+  if (errorMessage.includes("model not found") || errorMessage.includes("MODEL_NOT_FOUND")) {
+    return { kind: "continue", modelNotFound: true };
+  }
+
+  if (errorMessage.includes("not supported") || errorMessage.includes("NOT_SUPPORTED")) {
+    return { kind: "continue", modelNotSupportedForAccount: true, requestError: true };
+  }
+
+  if (errorMessage.includes("invalid request") || errorMessage.includes("INVALID_ARGUMENT")) {
+    return { kind: "continue", requestError: true, upstreamInvalidRequest: true };
+  }
+
+  return { kind: "continue", requestError: true };
+}
+
 export class GeminiChatProviderStrategy extends BaseProviderStrategy implements DirectExecutionProviderStrategy {
   public readonly mode = "gemini_chat" as const;
 
@@ -783,26 +808,7 @@ export class GeminiChatProviderStrategy extends BaseProviderStrategy implements 
         return { kind: "handled" };
       }
     } catch (error) {
-      // Handle specific Gemini SDK errors
-      const errorMessage = String(error);
-      
-      if (errorMessage.includes("rate limit") || errorMessage.includes("RATE_LIMIT")) {
-        return { kind: "continue", rateLimit: true };
-      }
-      
-      if (errorMessage.includes("model not found") || errorMessage.includes("MODEL_NOT_FOUND")) {
-        return { kind: "continue", modelNotFound: true };
-      }
-      
-      if (errorMessage.includes("not supported") || errorMessage.includes("NOT_SUPPORTED")) {
-        return { kind: "continue", modelNotSupportedForAccount: true, requestError: true };
-      }
-      
-      if (errorMessage.includes("invalid request") || errorMessage.includes("INVALID_ARGUMENT")) {
-        return { kind: "continue", requestError: true, upstreamInvalidRequest: true };
-      }
-
-      return { kind: "continue", requestError: true };
+      return classifyGeminiSdkError(String(error));
     }
   }
 

--- a/src/lib/provider-strategy/strategies/gemini.ts
+++ b/src/lib/provider-strategy/strategies/gemini.ts
@@ -722,6 +722,27 @@ export class GeminiChatProviderStrategy extends BaseProviderStrategy implements 
         }
         rawResponse.flushHeaders();
 
+        // Extend queue timeout now that streaming has started successfully
+        const signal = context.queueSignal;
+        if (signal && typeof (signal as any).extendTimeout === "function") {
+          (signal as any).extendTimeout();
+        }
+
+        // Emit SSE error if the queue aborts us mid-stream
+        if (signal) {
+          const onAbort = () => {
+            if (!rawResponse.writableEnded) {
+              rawResponse.write(
+                `data: ${JSON.stringify({
+                  error: { message: "Provider stream aborted by request queue timeout" },
+                })}\n\n`
+              );
+              rawResponse.end();
+            }
+          };
+          signal.addEventListener("abort", onAbort, { once: true });
+        }
+
         try {
           let accumulatedText = "";
           let accumulatedReasoning = "";

--- a/src/lib/provider-strategy/strategies/ollama-cloud.ts
+++ b/src/lib/provider-strategy/strategies/ollama-cloud.ts
@@ -77,8 +77,9 @@ export class OllamaCloudProviderStrategy extends BaseProviderStrategy {
 
       // Extend queue timeout now that streaming has started successfully
       const signal = context.queueSignal;
-      if (signal && typeof (signal as any).extendTimeout === "function") {
-        (signal as any).extendTimeout();
+      const extendedSignal = signal as AbortSignal & { extendTimeout?: () => void } | undefined;
+      if (extendedSignal && typeof extendedSignal.extendTimeout === "function") {
+        extendedSignal.extendTimeout();
       }
 
       // Emit SSE error if the queue aborts us mid-stream

--- a/src/lib/provider-strategy/strategies/ollama-cloud.ts
+++ b/src/lib/provider-strategy/strategies/ollama-cloud.ts
@@ -75,6 +75,27 @@ export class OllamaCloudProviderStrategy extends BaseProviderStrategy {
       }
       rawResponse.flushHeaders();
 
+      // Extend queue timeout now that streaming has started successfully
+      const signal = context.queueSignal;
+      if (signal && typeof (signal as any).extendTimeout === "function") {
+        (signal as any).extendTimeout();
+      }
+
+      // Emit SSE error if the queue aborts us mid-stream
+      if (signal) {
+        const onAbort = () => {
+          if (!rawResponse.writableEnded) {
+            rawResponse.write(
+              `data: ${JSON.stringify({
+                error: { message: "Provider stream aborted by request queue timeout" },
+              })}\n\n`
+            );
+            rawResponse.end();
+          }
+        };
+        signal.addEventListener("abort", onAbort, { once: true });
+      }
+
       try {
         await streamOllamaNdjsonToChatCompletionSse(upstreamResponse.body, context.routedModel, (data) => {
           rawResponse.write(data);
@@ -82,7 +103,8 @@ export class OllamaCloudProviderStrategy extends BaseProviderStrategy {
         });
       } catch (error) {
         if (!rawResponse.writableEnded) {
-          rawResponse.write(`data: ${JSON.stringify({ error: { message: toErrorMessage(error) } })}\n\n`);
+          rawResponse.write(`data: ${JSON.stringify({ error: { message: toErrorMessage(error) } })}
+\n`);
         }
       }
 

--- a/src/lib/provider-strategy/strategies/ollama.ts
+++ b/src/lib/provider-strategy/strategies/ollama.ts
@@ -131,8 +131,9 @@ export class OllamaProviderStrategy extends BaseProviderStrategy {
 
       // Extend queue timeout now that streaming has started successfully
       const signal = context.queueSignal;
-      if (signal && typeof (signal as any).extendTimeout === "function") {
-        (signal as any).extendTimeout();
+      const extendedSignal = signal as AbortSignal & { extendTimeout?: () => void } | undefined;
+      if (extendedSignal && typeof extendedSignal.extendTimeout === "function") {
+        extendedSignal.extendTimeout();
       }
 
       // Emit SSE error if the queue aborts us mid-stream

--- a/src/lib/provider-strategy/strategies/ollama.ts
+++ b/src/lib/provider-strategy/strategies/ollama.ts
@@ -129,6 +129,27 @@ export class OllamaProviderStrategy extends BaseProviderStrategy {
       }
       rawResponse.flushHeaders();
 
+      // Extend queue timeout now that streaming has started successfully
+      const signal = context.queueSignal;
+      if (signal && typeof (signal as any).extendTimeout === "function") {
+        (signal as any).extendTimeout();
+      }
+
+      // Emit SSE error if the queue aborts us mid-stream
+      if (signal) {
+        const onAbort = () => {
+          if (!rawResponse.writableEnded) {
+            rawResponse.write(
+              `data: ${JSON.stringify({
+                error: { message: "Provider stream aborted by request queue timeout" },
+              })}\n\n`
+            );
+            rawResponse.end();
+          }
+        };
+        signal.addEventListener("abort", onAbort, { once: true });
+      }
+
       try {
         await streamOllamaNdjsonToChatCompletionSse(upstreamResponse.body, context.routedModel, (data) => {
           rawResponse.write(data);

--- a/src/lib/provider-strategy/strategies/openai.ts
+++ b/src/lib/provider-strategy/strategies/openai.ts
@@ -104,6 +104,12 @@ async function streamResponsesPassthroughToClient(
   }
   rawResponse.flushHeaders();
 
+  // Extend queue timeout now that streaming has started successfully
+  const signal = context.queueSignal;
+  if (signal && typeof (signal as any).extendTimeout === "function") {
+    (signal as any).extendTimeout();
+  }
+
   try {
     if (firstChunk.value && firstChunk.value.byteLength > 0) {
       rawResponse.write(firstChunk.value);
@@ -134,6 +140,13 @@ async function streamResponsesPassthroughToClient(
       // Ignore reader release errors while closing the downstream stream.
     }
     if (!rawResponse.writableEnded) {
+      if (signal?.aborted) {
+        rawResponse.write(
+          `data: ${JSON.stringify({
+            error: { message: "Provider stream aborted by request queue timeout" },
+          })}\n\n`
+        );
+      }
       rawResponse.end();
     }
   }

--- a/src/lib/provider-strategy/strategies/openai.ts
+++ b/src/lib/provider-strategy/strategies/openai.ts
@@ -106,8 +106,9 @@ async function streamResponsesPassthroughToClient(
 
   // Extend queue timeout now that streaming has started successfully
   const signal = context.queueSignal;
-  if (signal && typeof (signal as any).extendTimeout === "function") {
-    (signal as any).extendTimeout();
+  const extendedSignal = signal as AbortSignal & { extendTimeout?: () => void } | undefined;
+  if (extendedSignal && typeof extendedSignal.extendTimeout === "function") {
+    extendedSignal.extendTimeout();
   }
 
   try {

--- a/src/lib/provider-strategy/strategies/responses-event-stream.ts
+++ b/src/lib/provider-strategy/strategies/responses-event-stream.ts
@@ -30,8 +30,9 @@ export async function handleResponsesEventStreamAsChatCompletion(
 
     // Extend queue timeout now that streaming has started successfully
     const signal = context.queueSignal;
-    if (signal && typeof (signal as any).extendTimeout === "function") {
-      (signal as any).extendTimeout();
+    const extendedSignal = signal as AbortSignal & { extendTimeout?: () => void } | undefined;
+    if (extendedSignal && typeof extendedSignal.extendTimeout === "function") {
+      extendedSignal.extendTimeout();
     }
 
     // Emit SSE error if the queue aborts us mid-stream

--- a/src/lib/provider-strategy/strategies/responses-event-stream.ts
+++ b/src/lib/provider-strategy/strategies/responses-event-stream.ts
@@ -28,6 +28,27 @@ export async function handleResponsesEventStreamAsChatCompletion(
     }
     rawResponse.flushHeaders();
 
+    // Extend queue timeout now that streaming has started successfully
+    const signal = context.queueSignal;
+    if (signal && typeof (signal as any).extendTimeout === "function") {
+      (signal as any).extendTimeout();
+    }
+
+    // Emit SSE error if the queue aborts us mid-stream
+    if (signal) {
+      const onAbort = () => {
+        if (!rawResponse.writableEnded) {
+          rawResponse.write(
+            `data: ${JSON.stringify({
+              error: { message: "Provider stream aborted by request queue timeout" },
+            })}\n\n`
+          );
+          rawResponse.end();
+        }
+      };
+      signal.addEventListener("abort", onAbort, { once: true });
+    }
+
     try {
       const result = await streamResponsesSseToChatCompletionChunks(
         upstreamResponse.body,

--- a/src/lib/provider-strategy/strategies/standard.ts
+++ b/src/lib/provider-strategy/strategies/standard.ts
@@ -152,6 +152,13 @@ export class ResponsesProviderStrategy extends TransformedJsonProviderStrategy {
         }
       }
       rawResponse.flushHeaders();
+
+      // Extend queue timeout now that streaming has started successfully
+      const signal = context.queueSignal;
+      if (signal && typeof (signal as any).extendTimeout === "function") {
+        (signal as any).extendTimeout();
+      }
+
       await writeInterleavedResponsesSse(upstreamJson, context.routedModel, (data) => rawResponse.write(data));
       rawResponse.end();
       return { kind: "handled" };
@@ -322,12 +329,36 @@ export class ResponsesPassthroughStrategy extends BaseProviderStrategy {
         }
       }
       rawResponse.flushHeaders();
+
+      // Extend queue timeout now that streaming has started successfully
+      const signal = context.queueSignal;
+      if (signal && typeof (signal as any).extendTimeout === "function") {
+        (signal as any).extendTimeout();
+      }
+
       const nodeStream = Readable.fromWeb(upstreamResponse.body as never);
       nodeStream.on("error", () => {
         if (!rawResponse.writableEnded) {
           rawResponse.end();
         }
       });
+
+      // Emit SSE error if the queue aborts us mid-stream
+      if (signal) {
+        const onAbort = () => {
+          if (!rawResponse.writableEnded) {
+            rawResponse.write(
+              `data: ${JSON.stringify({
+                error: { message: "Provider stream aborted by request queue timeout" },
+              })}\n\n`
+            );
+            rawResponse.end();
+          }
+        };
+        signal.addEventListener("abort", onAbort, { once: true });
+        nodeStream.on("end", () => signal.removeEventListener("abort", onAbort));
+      }
+
       nodeStream.pipe(rawResponse);
       return { kind: "handled" };
     }

--- a/src/lib/provider-strategy/strategies/standard.ts
+++ b/src/lib/provider-strategy/strategies/standard.ts
@@ -155,8 +155,9 @@ export class ResponsesProviderStrategy extends TransformedJsonProviderStrategy {
 
       // Extend queue timeout now that streaming has started successfully
       const signal = context.queueSignal;
-      if (signal && typeof (signal as any).extendTimeout === "function") {
-        (signal as any).extendTimeout();
+      const extendedSignal = signal as AbortSignal & { extendTimeout?: () => void } | undefined;
+      if (extendedSignal && typeof extendedSignal.extendTimeout === "function") {
+        extendedSignal.extendTimeout();
       }
 
       await writeInterleavedResponsesSse(upstreamJson, context.routedModel, (data) => rawResponse.write(data));
@@ -332,8 +333,9 @@ export class ResponsesPassthroughStrategy extends BaseProviderStrategy {
 
       // Extend queue timeout now that streaming has started successfully
       const signal = context.queueSignal;
-      if (signal && typeof (signal as any).extendTimeout === "function") {
-        (signal as any).extendTimeout();
+      const extendedSignal = signal as AbortSignal & { extendTimeout?: () => void } | undefined;
+      if (extendedSignal && typeof extendedSignal.extendTimeout === "function") {
+        extendedSignal.extendTimeout();
       }
 
       const nodeStream = Readable.fromWeb(upstreamResponse.body as never);

--- a/src/lib/provider-utils.ts
+++ b/src/lib/provider-utils.ts
@@ -93,16 +93,22 @@ export async function runCljsQueued<T>(
 export function sendQueueError(reply: FastifyReply, error: unknown): boolean {
   const data = errorData(error);
   const code = keywordName(data?.code);
-  if (code === "queue/full") {
+
+  function setRetryAfter(): void {
     const retryAfterMs = data?.["retry-after-ms"] ?? data?.retryAfterMs;
     if (typeof retryAfterMs === "number" && Number.isFinite(retryAfterMs)) {
       reply.header("retry-after", String(Math.max(1, Math.ceil(retryAfterMs / 1000))));
     }
+  }
+
+  if (code === "queue/full") {
+    setRetryAfter();
     sendOpenAiError(reply, 429, "Request queue full", "server_error", "queue_full");
     return true;
   }
-  if (code === "queue/dropped" || code === "queue/total-timeout" || code === "queue/exhausted") {
-    sendOpenAiError(reply, 503, "Request queue dropped or timed out", "server_error", "queue_dropped");
+  if (code === "queue/dropped" || code === "queue/total-timeout" || code === "queue/attempt-timeout" || code === "queue/exhausted") {
+    setRetryAfter();
+    sendOpenAiError(reply, 429, "Request queue dropped or timed out", "server_error", "queue_dropped");
     return true;
   }
   return false;

--- a/src/lib/proxy.ts
+++ b/src/lib/proxy.ts
@@ -2,6 +2,7 @@ import type { IncomingHttpHeaders } from "node:http";
 import type { FastifyReply } from "fastify";
 
 import type { ProviderCredential } from "./key-pool.js";
+import { getActiveCljsRuntime } from "./cljs-runtime.js";
 
 const HOP_BY_HOP_HEADERS = new Set([
   "connection",
@@ -212,7 +213,33 @@ export function classifyRateLimitKind(
   errorBody: unknown,
   retryAfterMs: number | undefined,
   concurrencyThresholdMs: number = 30_000,
+  providerId?: string,
 ): RateLimitKind {
+  // Check provider-specific EDN policy first.
+  if (providerId) {
+    const runtime = getActiveCljsRuntime();
+    if (runtime?.classifyRateLimit) {
+      try {
+        const cljsResult = runtime.classifyRateLimit(
+          "resources/policies/runtime/00-manifest.edn",
+          providerId,
+          429,
+          retryAfterMs,
+        );
+        if (cljsResult.status === "ok" && cljsResult.result) {
+          if (cljsResult.result === "volume") {
+            return "quota_exhausted";
+          }
+          if (cljsResult.result === "concurrency") {
+            return "concurrency_throttle";
+          }
+        }
+      } catch {
+        // Fall back to generic heuristics on CLJS error.
+      }
+    }
+  }
+
   // Ollama session/weekly limits are always quota exhaustion.
   const ollamaKind = detectOllamaLimitKind(errorBody);
   if (ollamaKind === "session" || ollamaKind === "weekly") {

--- a/src/lib/proxy.ts
+++ b/src/lib/proxy.ts
@@ -214,6 +214,7 @@ export function classifyRateLimitKind(
   retryAfterMs: number | undefined,
   concurrencyThresholdMs: number = 30_000,
   providerId?: string,
+  manifestPath?: string,
 ): RateLimitKind {
   // Check provider-specific EDN policy first.
   if (providerId) {
@@ -221,7 +222,7 @@ export function classifyRateLimitKind(
     if (runtime?.classifyRateLimit) {
       try {
         const cljsResult = runtime.classifyRateLimit(
-          "resources/policies/runtime/00-manifest.edn",
+          manifestPath ?? "resources/policies/runtime/00-manifest.edn",
           providerId,
           429,
           retryAfterMs,

--- a/src/proxx/policy/contracts.cljs
+++ b/src/proxx/policy/contracts.cljs
@@ -100,6 +100,11 @@
        (filter #(= :request-queue-instance (:contract/kind %)))
        vec))
 
+(defn rate-limit-classifications [idx]
+  (->> (:contracts idx)
+       (filter #(= :rate-limit-classification (:contract/kind %)))
+       vec))
+
 (defn- provider-route-provider-id [route]
   (or (:provider/id route)
       (:provider-id route)

--- a/src/proxx/policy/contracts.cljs
+++ b/src/proxx/policy/contracts.cljs
@@ -236,7 +236,7 @@
         (some #(when (= :account-order/prefer-free (:contract/id %)) %)
               (:account-orderings compiled)))))
 
-(defn- normalized-keyword [value]
+(defn normalized-keyword [value]
   (cond
     (keyword? value) value
     (string? value) (keyword (str/replace value #"_" "-"))
@@ -303,7 +303,7 @@
     {:ordered (vec (order-accounts ordering quota-filtered))
      :applies-constraint (:applies-constraint constrained)}))
 
-(defn- strategy-mode [strategy]
+(defn strategy-mode [strategy]
   (normalized-keyword (or (:mode strategy)
                           (:strategy/mode strategy)
                           strategy)))
@@ -509,7 +509,7 @@
 
       :else true)))
 
-(defn- request-surface-provider-allowed?
+(defn request-surface-provider-allowed?
   "Return true when declarative request-surface defaults allow provider-id.
 
   Provider capability clauses tune strategy preference. Request-surface-default
@@ -808,7 +808,7 @@
       (lookup-provider-value by-provider provider-id [])
       (or (:accounts input) []))))
 
-(defn- strategies-for-provider [input provider-id]
+(defn strategies-for-provider [input provider-id]
   (let [by-provider (or (get-any input [:strategies-by-provider :strategiesByProvider]) {})]
     (if (seq by-provider)
       (lookup-provider-value by-provider provider-id [])
@@ -839,7 +839,7 @@
 (defn- dedupe-provider-ids [provider-ids]
   (dedupe-provider-id-values provider-ids))
 
-(defn- request-or-route-provider-ids [route input]
+(defn request-or-route-provider-ids [route input]
   (let [available-provider-ids (if-let [provider-ids (seq (or (get-any input [:provider-ids :providerIds]) []))]
                                  (dedupe-provider-ids provider-ids)
                                  (dedupe-provider-ids (route-default-provider-ids route)))
@@ -997,7 +997,7 @@
   (let [by-id (provider-route-by-id compiled)]
     (filterv #(not (contains? by-id %)) provider-ids)))
 
-(defn- evidence-filtered-provider-ids [route input provider-ids model-id]
+(defn evidence-filtered-provider-ids [route input provider-ids model-id]
   (if (= :route/default (:contract/id route))
     (let [evidenced (filterv #(provider-model-evidenced? input % model-id) provider-ids)]
       (if (seq evidenced) evidenced provider-ids))

--- a/src/proxx/policy/search.cljs
+++ b/src/proxx/policy/search.cljs
@@ -1,0 +1,277 @@
+(ns proxx.policy.search
+  "Prolog-inspired depth-first policy tree search with backtracking.
+
+   The policy engine compiles declarative EDN contracts into a search tree:
+
+     routing-clause
+       └── provider
+             └── strategy
+                   └── account (terminal)
+
+   Execution is lazy depth-first search. When a terminal account fails,
+   the search backtracks to the nearest sibling with unexplored children.
+   This replaces the flat candidate-list approach with a structured decision
+   tree that respects provider-strategy-account hierarchy."
+  (:require [clojure.string :as str]
+            [proxx.policy.contracts :as contracts]))
+
+;; ─────────────────────────────────────────────────────────────────────────────
+;; Search tree nodes
+
+(defrecord TreeNode [branch-type rule children-fn context])
+
+(defn- terminal-node
+  "Create a leaf node carrying the full projected context."
+  [context]
+  (->TreeNode :terminal nil nil context))
+
+(defn- branch-node
+  "Create an internal node with a lazy children factory."
+  [branch-type rule children-fn context]
+  (->TreeNode branch-type rule children-fn context))
+
+;; ─────────────────────────────────────────────────────────────────────────────
+;; Tree compilation from compiled policy contracts
+
+(defn- provider-route-for-id
+  "Find the provider route map for a given provider id."
+  [compiled provider-id]
+  (some #(when (= provider-id (or (:provider/id %) (:provider-id %))) %)
+        (:provider-routes compiled)))
+
+(defn- strategies-for-provider-input
+  "Return ordered strategy modes for a provider + request kind from input."
+  [compiled route provider-id request-kind input]
+  (let [strategies (contracts/strategies-for-provider input provider-id)
+        ordered (contracts/order-strategy-candidates compiled route provider-id request-kind strategies)]
+    (mapv contracts/strategy-mode ordered)))
+
+(defn- accounts-for-provider
+  "Return ordered accounts for a provider from the input context."
+  [input provider-id]
+  (let [provider-key (if (keyword? provider-id) provider-id (keyword provider-id))
+        accounts (vec (or (get-in input [:accounts-by-provider provider-key])
+                          (get-in input [:accountsByProvider provider-key])
+                          (get-in input [:accounts-by-provider provider-id])
+                          (get-in input [:accountsByProvider provider-id])
+                          []))]
+    accounts))
+
+(defn- build-account-children
+  "Build terminal account nodes for a provider+strategy path."
+  [compiled route provider-id strategy-mode input base-url paths]
+  (let [raw-accounts (accounts-for-provider input provider-id)
+        account-result (contracts/order-account-candidates compiled route raw-accounts)
+        ordered-accounts (:ordered account-result)]
+    (mapv (fn [account]
+            (terminal-node
+             {:provider-id provider-id
+              :base-url base-url
+              :paths paths
+              :account account
+              :strategy-mode (name strategy-mode)
+              :routing-clause-id (:contract/id route)
+              :projected-facts {:routing-clause route
+                                :provider-id provider-id
+                                :strategy-mode strategy-mode
+                                :account account
+                                :applies-account-constraint (:applies-constraint account-result)}}))
+          ordered-accounts)))
+
+(defn- build-strategy-children
+  "Build strategy branch nodes for a provider."
+  [compiled route provider-id input base-url paths]
+  (let [request-kind (contracts/normalized-keyword
+                      (or (get input :request-kind)
+                          (get input :requestKind)
+                          :chat))
+        strategy-modes (strategies-for-provider-input compiled route provider-id request-kind input)]
+    (mapv (fn [mode]
+            (branch-node
+             :strategy
+             {:strategy-mode mode}
+             (fn [] (build-account-children compiled route provider-id mode input base-url paths))
+             {:provider-id provider-id
+              :strategy-mode mode}))
+          strategy-modes)))
+
+(defn- build-provider-children
+  "Build provider branch nodes for a routing clause."
+  [compiled route input]
+  (let [provider-ids (contracts/request-or-route-provider-ids route input)
+        surface-providers (filterv #(contracts/request-surface-provider-allowed? compiled % (:request-kind input))
+                                   provider-ids)
+        evidenced-providers (contracts/evidence-filtered-provider-ids route input surface-providers
+                                                                      (or (get input :model-id)
+                                                                          (get input :modelId)
+                                                                          ""))
+        tenant-settings (or (get input :tenant-settings)
+                            (get input :tenantSettings)
+                            {})
+        tenant-allowed (filterv #(contracts/tenant-provider-allowed? tenant-settings %) evidenced-providers)
+        ordered-providers (vec (contracts/order-provider-candidates route tenant-allowed))]
+    (mapv (fn [provider-id]
+            (let [route-info (provider-route-for-id compiled provider-id)
+                  base-url (or (:provider/base-url route-info)
+                               (:provider/baseUrl route-info)
+                               "")
+                  paths (:provider/paths route-info)]
+              (branch-node
+               :provider
+               {:provider-id provider-id}
+               (fn [] (build-strategy-children compiled route provider-id input base-url paths))
+               {:provider-id provider-id
+                :base-url base-url})))
+          ordered-providers)))
+
+(defn- build-routing-clause-children
+  "Build routing clause branch nodes from compiled contracts."
+  [compiled input]
+  (let [model-id (or (get input :model-id)
+                     (get input :modelId)
+                     "")
+        clauses (:routing-clauses compiled)
+        matching (filterv #(contracts/routing-clause-matches-model? % model-id) clauses)]
+    (mapv (fn [clause]
+            (branch-node
+             :routing-clause
+             {:clause-id (:contract/id clause)}
+             (fn [] (build-provider-children compiled clause input))
+             {:routing-clause clause}))
+          matching)))
+
+(defn compile-policy-tree
+  "Compile compiled policy contracts into a lazy search tree.
+
+   Input is a map with:
+     :model-id / :modelId        — requested model
+     :request-kind / :requestKind — :chat, :embeddings, etc.
+     :tenant-settings            — tenant authorization map
+     :accounts-by-provider       — map of provider-id -> account array
+
+   Returns a TreeNode (the root)."
+  [compiled input]
+  (branch-node
+   :root
+   {:model-id (or (get input :model-id) (get input :modelId) "")}
+   (fn [] (build-routing-clause-children compiled input))
+   {}))
+
+;; ─────────────────────────────────────────────────────────────────────────────
+;; Depth-first search with backtracking
+
+(defn- node-children
+  "Materialize children for a branch node. Caches on first access."
+  [node]
+  (when-let [factory (:children-fn node)]
+    (factory)))
+
+(defn dfs-execute
+  "Execute depth-first search over a policy tree.
+
+   try-candidate is a function of (terminal-context) that returns either:
+     {:status :success :result <anything>}  — search terminates, returns this
+     {:status :failure :reason <keyword>}   — backtrack and try next sibling
+
+   Returns:
+     {:status :success :result <anything>}  — a terminal succeeded
+     {:status :exhausted :trace <vector>}   — all terminals failed"
+  [tree try-candidate]
+  (loop [stack [{:node tree :child-index 0}]
+         trace []]
+    (if (empty? stack)
+      {:status :exhausted :trace trace}
+      (let [frame (peek stack)
+            node (:node frame)
+            idx (:child-index frame)]
+        (if (= :terminal (:branch-type node))
+          (let [ctx (:context node)
+                result (try-candidate ctx)]
+            (if (= :success (:status result))
+              (assoc result :trace (conj trace {:branch-type :terminal
+                                                :context ctx
+                                                :outcome :success}))
+              (recur (pop stack)
+                     (conj trace {:branch-type :terminal
+                                  :context ctx
+                                  :outcome (:status result)
+                                  :reason (:reason result)}))))
+          (let [children (node-children node)]
+            (if (and (seq children) (< idx (count children)))
+              (recur (conj (pop stack)
+                          (assoc frame :child-index (inc idx))
+                          {:node (nth children idx) :child-index 0})
+                     (conj trace {:branch-type (:branch-type node)
+                                  :rule (:rule node)
+                                  :child-index idx
+                                  :total-children (count children)}))
+              (recur (pop stack)
+                     (conj trace {:branch-type (:branch-type node)
+                                  :rule (:rule node)
+                                  :outcome :exhausted})))))))))
+
+;; ─────────────────────────────────────────────────────────────────────────────
+;; Convenience: execute with async JS callback
+
+(defn execute-policy-tree
+  "Execute policy tree with a JS async callback.
+
+   try-candidate-js is a JS function of (context-js) returning a JS Promise.
+   The promise should resolve to {:status 'success'/'failure' ...}.
+
+   Returns a CLJS promise resolving to the search result."
+  [tree try-candidate-js]
+  (letfn [(advance [stack trace]
+            ;; Pop exhausted frames until we find one with unexplored children
+            (loop [s stack
+                   t trace]
+              (if (empty? s)
+                {:status :exhausted :trace t}
+                (let [frame (peek s)
+                      node (:node frame)
+                      idx (:child-index frame)
+                      children (node-children node)]
+                  (if (and (seq children) (< idx (count children)))
+                    ;; Found a frame with unexplored children
+                    (let [child (nth children idx)
+                          new-stack (conj (pop s)
+                                          (assoc frame :child-index (inc idx))
+                                          {:node child :child-index 0})]
+                      (explore new-stack (conj t {:branch-type (:branch-type node)
+                                                  :rule (:rule node)
+                                                  :child-index idx
+                                                  :total-children (count children)})))
+                    ;; This frame exhausted, keep popping
+                    (recur (pop s) (conj t {:branch-type (:branch-type node)
+                                            :rule (:rule node)
+                                            :outcome :exhausted})))))))
+          (explore [stack trace]
+            (if (empty? stack)
+              {:status :exhausted :trace trace}
+              (let [frame (peek stack)
+                    node (:node frame)]
+                (if (= :terminal (:branch-type node))
+                  ;; Try the terminal candidate asynchronously
+                  (-> (js/Promise.resolve (try-candidate-js (clj->js (:context node))))
+                      (.then (fn [js-result]
+                               (let [result (js->clj js-result :keywordize-keys true)]
+                                 (if (= "success" (get result :status))
+                                    {:status :success
+                                     :result (merge (:context node) result)
+                                     :trace (conj trace {:branch-type :terminal
+                                                         :context (:context node)
+                                                         :outcome :success})}
+                                   (advance (pop stack)
+                                            (conj trace {:branch-type :terminal
+                                                        :context (:context node)
+                                                        :outcome :failure
+                                                        :reason (get result :reason)}))))))
+                      (.catch (fn [err]
+                                (advance (pop stack)
+                                         (conj trace {:branch-type :terminal
+                                                     :context (:context node)
+                                                     :outcome :exception
+                                                     :error (.-message err)})))))
+                  ;; Branch node — advance to next child
+                  (advance stack trace)))))]
+    (js/Promise.resolve (explore [{:node tree :child-index 0}] []))))

--- a/src/proxx/policy/search.cljs
+++ b/src/proxx/policy/search.cljs
@@ -12,8 +12,7 @@
    the search backtracks to the nearest sibling with unexplored children.
    This replaces the flat candidate-list approach with a structured decision
    tree that respects provider-strategy-account hierarchy."
-  (:require [clojure.string :as str]
-            [proxx.policy.contracts :as contracts]))
+  (:require [proxx.policy.contracts :as contracts]))
 
 ;; ─────────────────────────────────────────────────────────────────────────────
 ;; Search tree nodes

--- a/src/proxx/queue/policy.cljs
+++ b/src/proxx/queue/policy.cljs
@@ -1,6 +1,7 @@
 (ns proxx.queue.policy
   "Pure request queue policy functions. No I/O, no mutable runtime state."
-  (:require [clojure.string :as str]))
+  (:require [clojure.string :as str]
+            [proxx.policy.contracts :as contracts]))
 
 (def queue-policy-keys
   [:queue/status
@@ -14,7 +15,8 @@
    :queue/fail-fast?
    :queue/jitter-factor
    :queue/base-interval-ms
-   :queue/retry-after-respect?])
+   :queue/retry-after-respect?
+   :queue/stream-timeout-ms])
 
 (defn- template-by-id [compiled template-id]
   (get-in compiled [:index :by-id template-id]))
@@ -107,3 +109,21 @@
                             (max 0 (- date-ms (js/Date.now)))))
                         (* 1000 seconds)))
     :else nil))
+
+(defn classify-rate-limit
+  "Classify a rate-limit response based on provider-specific EDN contracts.
+   Returns :rate-limit/volume, :rate-limit/concurrency, or nil when no contract matches."
+  [compiled provider-id status retry-after-ms]
+  (when-let [contract (first
+                        (filter
+                          (fn [c]
+                            (and
+                              (= provider-id (:match/provider-id c))
+                              (or (nil? (:classify/status c))
+                                  (= status (:classify/status c)))
+                              (let [max-ms (get-in c [:classify/retry-after-ms :max])]
+                                (or (nil? max-ms)
+                                    (and (number? retry-after-ms)
+                                         (<= retry-after-ms max-ms))))))
+                          (contracts/rate-limit-classifications (:index compiled))))]
+    (:classify/result contract)))

--- a/src/proxx/queue/runtime.cljs
+++ b/src/proxx/queue/runtime.cljs
@@ -47,25 +47,26 @@
             :retry-after-ms (policy/drain-estimate-ms policy active-count)
             :limit          (:queue/max-queue-size policy)}))
 
-(defn- queue-dropped-error []
+(defn- queue-dropped-error [policy active-count]
   (ex-info "Request dropped: queue at capacity"
-           {:code :queue/dropped}))
+           {:code           :queue/dropped
+            :retry-after-ms (policy/drain-estimate-ms policy active-count)}))
 
 (defn- queue-wait-timeout-error []
   (ex-info "Timed out waiting in queue"
-           {:code :queue/total-timeout :attempt 0}))
+           {:code :queue/total-timeout :attempt 0 :retry-after-ms 5000}))
 
 (defn- attempt-timeout-error [attempt]
   (ex-info (str "Attempt " attempt " timed out")
-           {:code :queue/attempt-timeout :attempt attempt}))
+           {:code :queue/attempt-timeout :attempt attempt :retry-after-ms 5000}))
 
 (defn- exhausted-error []
   (ex-info "Max retries exhausted"
-           {:code :queue/exhausted}))
+           {:code :queue/exhausted :retry-after-ms 10000}))
 
 (defn- total-timeout-error [attempt]
   (ex-info "Total timeout exceeded"
-           {:code :queue/total-timeout :attempt attempt}))
+           {:code :queue/total-timeout :attempt attempt :retry-after-ms 5000}))
 
 ;; ── Waiter construction ───────────────────────────────────────
 
@@ -99,7 +100,7 @@
       (>= queued max-q)
       (throw (if (= (:queue/overflow-policy policy) :reject)
                (queue-full-error policy active)
-               (queue-dropped-error)))
+                (queue-dropped-error policy active)))
 
       :else
       (await (park-caller! state-atom total-deadline)))))

--- a/src/proxx/queue/runtime.cljs
+++ b/src/proxx/queue/runtime.cljs
@@ -125,12 +125,22 @@
 (defn ^:async run-attempt [task attempt policy total-deadline]
   (let [controller (js/AbortController.)
         tms        (effective-timeout-ms policy total-deadline)
-        timer      (arm-abort-timer! controller tms)
+        timer-ref  (atom (arm-abort-timer! controller tms))
+        completed? (atom false)
+        extend-timeout! (fn []
+                          (when-not @completed?
+                            (let [stream-tms (:queue/stream-timeout-ms policy 120000)]
+                              (js/clearTimeout @timer-ref)
+                              (reset! timer-ref (arm-abort-timer! controller stream-tms)))))
         abort-p    (make-abort-promise (.-signal controller) attempt)]
+    ;; Attach extendTimeout as a JS property for TS interop
+    (set! (.-extendTimeout controller) extend-timeout!)
+    (set! (.-extendTimeout (.-signal controller)) extend-timeout!)
     (try
       (await (js/Promise.race #js [(task controller) abort-p]))
       (finally
-        (js/clearTimeout timer)))))
+        (reset! completed? true)
+        (js/clearTimeout @timer-ref)))))
 
 ;; ── Retry classification ──────────────────────────────────────
 

--- a/src/proxx/runtime.cljs
+++ b/src/proxx/runtime.cljs
@@ -319,6 +319,19 @@
     (catch :default e
       (js/Promise.reject e))))
 
+(defn classify-rate-limit-js
+  "Classify a rate-limit response using provider-specific EDN contracts.
+   Returns a JS object with {status, result} where result is 'volume', 'concurrency', or null."
+  [manifest-path provider-id status retry-after-ms]
+  (try
+    (let [compiled (compiled-policy-for-manifest manifest-path)
+          result (queue-policy/classify-rate-limit compiled provider-id status retry-after-ms)]
+      (clj->js {:status "ok"
+                :result (when result (name result))}))
+    (catch :default e
+      (clj->js {:status "error"
+                :error (.-message e)}))))
+
 (def exports
   #js {:normalizeKeys normalize-keys-js
        :validateEntity validate-entity-js
@@ -338,4 +351,5 @@
         :authorizeTenantProviderPolicy authorize-tenant-provider-policy-js
         :runModelCandidates run-model-candidates-js
        :resolveQueuePolicy resolve-queue-policy-js
-       :runQueued run-queued-js})
+       :runQueued run-queued-js
+       :classifyRateLimit classify-rate-limit-js})

--- a/src/proxx/runtime.cljs
+++ b/src/proxx/runtime.cljs
@@ -5,6 +5,7 @@
             [proxx.policy.evidence :as policy-evidence]
             [proxx.policy.loader :as policy-loader]
             [proxx.policy.router :as router]
+            [proxx.policy.search :as policy-search]
             [proxx.processor :as processor]
             [proxx.queue.policy :as queue-policy]
             [proxx.queue.runtime :as queue-runtime]
@@ -125,6 +126,37 @@
       (clj->js {:status "error"
                 :error (.-message e)
                 :data (ex-data e)}))))
+
+(defn execute-policy-tree-js
+  "Compile policy contracts into a Prolog-inspired search tree and execute it
+   with backtracking.
+
+   try-candidate-js is a JS async function of (candidate-context-js) that returns
+   a JS Promise resolving to {:status 'success' ...} or {:status 'failure' ...}.
+
+   Returns a JS Promise resolving to:
+     {:status 'ok' :result <candidate-context> :trace [...]}
+     {:status 'exhausted' :trace [...]}"
+  [manifest-path input try-candidate-js]
+  (try
+    (let [compiled (compiled-policy-for-manifest manifest-path)
+          clj-input (js->clj (or input #js {}) :keywordize-keys true)
+          tree (policy-search/compile-policy-tree compiled clj-input)]
+       (-> (policy-search/execute-policy-tree tree try-candidate-js)
+           (.then (fn [result]
+                    (clj->js (assoc result :status (case (:status result)
+                                                      :success "ok"
+                                                      :exhausted "exhausted"
+                                                      (name (:status result)))))))
+           (.catch (fn [err]
+                     #js {"status" "error"
+                          "error" (.-message err)
+                          "data" (ex-data err)}))))
+    (catch :default e
+      (js/Promise.resolve
+       #js {"status" "error"
+            "error" (.-message e)
+            "data" (ex-data e)}))))
 
 (defn normalize-reasoning-request-js
   "Load declarative policy contracts and normalize request reasoning controls for
@@ -296,6 +328,7 @@
        :loadModelPricingOverrides load-model-pricing-overrides-js
        :loadProviderSeedSpecs load-provider-seed-specs-js
        :previewPolicyDecision preview-policy-decision-js
+       :executePolicyTree execute-policy-tree-js
        :normalizeReasoningRequest normalize-reasoning-request-js
        :resolveModelAlias resolve-model-alias-js
         :getProviderRoutes get-provider-routes-js

--- a/src/proxx/schema.cljs
+++ b/src/proxx/schema.cljs
@@ -438,10 +438,21 @@
                    (:match/family m)
                    (:match/request-kind m))))]
    [:fn {:error/message ":queue/total-timeout-ms must exceed :queue/attempt-timeout-ms"}
-    (fn [m]
-      (if (and (:queue/total-timeout-ms m) (:queue/attempt-timeout-ms m))
-        (> (:queue/total-timeout-ms m) (:queue/attempt-timeout-ms m))
-        true))]])
+     (fn [m]
+       (if (and (:queue/total-timeout-ms m) (:queue/attempt-timeout-ms m))
+         (> (:queue/total-timeout-ms m) (:queue/attempt-timeout-ms m))
+         true))]])
+
+(def RateLimitClassificationContract
+  [:and
+   ContractBase
+   [:map
+    [:contract/kind [:enum :rate-limit-classification]]
+    [:match/provider-id ProviderId]
+    [:classify/status {:optional true} [:int {:min 100 :max 599}]]
+    [:classify/retry-after-ms {:optional true}
+     [:map [:max [:int {:min 0}]]]]
+     [:classify/result [:enum :rate-limit/volume :rate-limit/concurrency]]]])
 
 (def PolicyProgramContract
   [:and
@@ -483,8 +494,9 @@
     [:model-alias ModelAliasContract]
     [:reasoning-normalization ReasoningNormalizationContract]
    [:request-queue-template RequestQueueTemplateContract]
-   [:request-queue-instance RequestQueueInstanceContract]
-   [:policy-program PolicyProgramContract]
+    [:request-queue-instance RequestQueueInstanceContract]
+    [:rate-limit-classification RateLimitClassificationContract]
+    [:policy-program PolicyProgramContract]
    [:strategy-binding StrategyBindingContract]
    [:policy Policy]
    [:strategy Policy]])

--- a/src/routes/embeddings.ts
+++ b/src/routes/embeddings.ts
@@ -2,7 +2,7 @@ import type { FastifyInstance } from "fastify";
 import type { AppDeps } from "../lib/app-deps.js";
 import { DEFAULT_TENANT_ID } from "../lib/tenant-api-key.js";
 import { joinUrl } from "../lib/http/index.js";
-import { getActiveCljsRuntime } from "../lib/cljs-runtime.js";
+import { getActiveCljsRuntime, resolveModelAliasWithCljs } from "../lib/cljs-runtime.js";
 import { buildForwardHeaders } from "../lib/proxy.js";
 import {
   nativeEmbedToOpenAiRequest,
@@ -121,7 +121,11 @@ export function registerEmbeddingsRoutes(deps: AppDeps, app: FastifyInstance): v
       const candidateIsOllama = !isOpenAiCompatEmbedProvider(candidateId);
 
       const candidateModel = candidateIsOllama
-        ? routingModelWithoutProviderPrefix
+        ? (resolveModelAliasWithCljs({
+            manifestPath: deps.config.cljsPolicyManifestPath,
+            modelId: routingModelWithoutProviderPrefix,
+            providerId: candidateId,
+          }) ?? routingModelWithoutProviderPrefix)
         : normalizeLlamacppModelName(routingModelWithoutProviderPrefix);
       const candidateEmbedBody = nativeEmbedToOpenAiRequest({ ...request.body, model: candidateModel });
       const inputSummary = summarizeEmbeddingInput(candidateEmbedBody.input);
@@ -149,7 +153,7 @@ export function registerEmbeddingsRoutes(deps: AppDeps, app: FastifyInstance): v
             deps.config.cljsPolicyManifestPath,
             { "tenant-id": request.openHaxAuth?.tenantId ?? "default", "provider-id": candidateId, "request-kind": "embeddings" },
             async (controller) => await ensureNativeOllamaEmbedContextFits(
-              deps.config.ollamaBaseUrl,
+              candidate.baseUrl,
               { model: candidateModel, input: candidateEmbedBody.input },
               Math.min(deps.config.requestTimeoutMs, 30_000),
               controller.signal,
@@ -185,7 +189,7 @@ export function registerEmbeddingsRoutes(deps: AppDeps, app: FastifyInstance): v
             deps.config.cljsPolicyManifestPath,
             { "tenant-id": request.openHaxAuth?.tenantId ?? "default", "provider-id": candidateId, "request-kind": "embeddings" },
             async (controller) => await fetchWithResponseTimeout(
-              joinUrl(deps.config.ollamaBaseUrl, "/api/embed"),
+              joinUrl(candidate.baseUrl, "/api/embed"),
               { method: "POST", headers: buildForwardHeaders(request.headers), body: JSON.stringify(upstreamBody), signal: controller.signal },
               deps.config.requestTimeoutMs,
             ),

--- a/src/tests/cljs-policy-preview.test.ts
+++ b/src/tests/cljs-policy-preview.test.ts
@@ -298,3 +298,113 @@ test("CLJS runtime authorizes tenant-provider share modes from federation policy
   assert.equal(projectionResult?.status, "ok");
   assert.equal(projectionResult?.allowed, false);
 });
+
+test("CLJS runtime executes policy tree with backtracking", async (t) => {
+  const loaded = await loadCljsRuntime({ required: false });
+  if (!loaded.loaded) {
+    t.skip(`CLJS runtime artifact not built: ${loaded.reason}`);
+    return;
+  }
+  await assertCljsRuntimeReady(loaded.runtime);
+
+  assert.equal(typeof loaded.runtime.executePolicyTree, "function");
+
+  const attempts: Array<{ readonly providerId: string; readonly accountId: string; readonly strategyMode: string }> = [];
+
+  const result = await loaded.runtime.executePolicyTree!(
+    "resources/policies/runtime/00-manifest.edn",
+    {
+      modelId: "gpt-5-mini",
+      requestKind: "chat",
+      tenantSettings: {
+        allowedProviderIds: ["openai", "factory"],
+      },
+      accountsByProvider: {
+        openai: [
+          { accountId: "free", planType: "free" },
+          { accountId: "plus", planType: "plus" },
+        ],
+        factory: [
+          { accountId: "team", planType: "team" },
+        ],
+      },
+      strategiesByProvider: {
+        openai: [
+          { mode: "chat-completions", priority: 1 },
+        ],
+        factory: [
+          { mode: "chat-completions", priority: 1 },
+        ],
+      },
+    },
+    (candidate: unknown) => {
+      const c = candidate as {
+        readonly "provider-id"?: string;
+        readonly account?: { readonly accountId?: string };
+        readonly "strategy-mode"?: string;
+      };
+      attempts.push({
+        providerId: c["provider-id"] ?? "",
+        accountId: c.account?.accountId ?? "",
+        strategyMode: c["strategy-mode"] ?? "",
+      });
+      // Fail the first attempt, succeed on the second
+      if (attempts.length < 2) {
+        return Promise.resolve({ status: "failure", reason: "simulated" });
+      }
+      return Promise.resolve({ status: "success" });
+    },
+  );
+
+  assert.equal(result.status, "ok");
+  assert.ok(result.result);
+  const resultCtx = result.result as {
+    readonly "provider-id"?: string;
+    readonly account?: { readonly accountId?: string };
+  };
+  // With gpt-free-blocked, free accounts are excluded.
+  // Order is: openai plus (fail) -> factory team (success)
+  assert.equal(resultCtx["provider-id"], "factory");
+  assert.equal(resultCtx.account?.accountId, "team");
+
+  assert.equal(attempts.length, 2);
+  assert.equal(attempts[0]?.providerId, "openai");
+  assert.equal(attempts[0]?.accountId, "plus");
+  assert.equal(attempts[1]?.providerId, "factory");
+  assert.equal(attempts[1]?.accountId, "team");
+});
+
+test("CLJS policy tree exhausts when all candidates fail", async (t) => {
+  const loaded = await loadCljsRuntime({ required: false });
+  if (!loaded.loaded) {
+    t.skip(`CLJS runtime artifact not built: ${loaded.reason}`);
+    return;
+  }
+  await assertCljsRuntimeReady(loaded.runtime);
+
+  const result = await loaded.runtime.executePolicyTree!(
+    "resources/policies/runtime/00-manifest.edn",
+    {
+      modelId: "gpt-5-mini",
+      requestKind: "chat",
+      tenantSettings: {
+        allowedProviderIds: ["openai"],
+      },
+      accountsByProvider: {
+        openai: [
+          { accountId: "plus", planType: "plus" },
+        ],
+      },
+      strategiesByProvider: {
+        openai: [
+          { mode: "chat-completions", priority: 1 },
+        ],
+      },
+    },
+    () => Promise.resolve({ status: "failure", reason: "always-fails" }),
+  );
+
+  assert.equal(result.status, "exhausted");
+  assert.ok(Array.isArray(result.trace));
+  assert.ok(result.trace.length > 0);
+});

--- a/src/tests/gemini-strategy.test.ts
+++ b/src/tests/gemini-strategy.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert";
 import { describe, test } from "node:test";
 import {
   GeminiChatProviderStrategy,
+  classifyGeminiSdkError,
   geminiPayloadToSdkRequest,
   geminiResponseToChatCompletion,
   openAiMessagesToGeminiContents,
@@ -794,5 +795,23 @@ describe("Gemini strategy end-to-end", () => {
     assert.equal(usage!.prompt_tokens, 10);
     assert.equal(usage!.completion_tokens, 5);
     assert.equal(usage!.total_tokens, 15);
+  });
+
+  test("classifyGeminiSdkError treats UNAVAILABLE/503 as rate limit", () => {
+    const unavailable = classifyGeminiSdkError("ApiError: got status: UNAVAILABLE. {\"error\":{\"code\":503}}");
+    assert.equal(unavailable.kind, "continue");
+    assert.equal((unavailable as Extract<typeof unavailable, { kind: "continue" }>).rateLimit, true);
+
+    const rateLimit = classifyGeminiSdkError("RATE_LIMIT_EXCEEDED");
+    assert.equal(rateLimit.kind, "continue");
+    assert.equal((rateLimit as Extract<typeof rateLimit, { kind: "continue" }>).rateLimit, true);
+
+    const modelNotFound = classifyGeminiSdkError("MODEL_NOT_FOUND");
+    assert.equal(modelNotFound.kind, "continue");
+    assert.equal((modelNotFound as Extract<typeof modelNotFound, { kind: "continue" }>).modelNotFound, true);
+
+    const generic = classifyGeminiSdkError("Some random error");
+    assert.equal(generic.kind, "continue");
+    assert.equal((generic as Extract<typeof generic, { kind: "continue" }>).requestError, true);
   });
 });

--- a/src/tests/queue-error-429.test.ts
+++ b/src/tests/queue-error-429.test.ts
@@ -1,0 +1,78 @@
+import { test } from "node:test";
+import assert from "node:assert";
+import { sendQueueError } from "../lib/provider-utils.js";
+
+interface MockReply {
+  header(name: string, value: string): MockReply;
+  code(s: number): MockReply;
+  send(data: unknown): void;
+  getStatus(): number;
+  getHeaders(): Record<string, string>;
+  getSent(): unknown;
+}
+
+function mockReply(): MockReply {
+  const headers: Record<string, string> = {};
+  let status = 0;
+  let sent: unknown = null;
+  return {
+    header(name: string, value: string) { headers[name] = value; return this; },
+    code(s: number) { status = s; return this; },
+    send(data: unknown) { sent = data; },
+    getStatus() { return status; },
+    getHeaders() { return headers; },
+    getSent() { return sent; },
+  };
+}
+
+test("sendQueueError: queue/dropped returns 429 with retry-after", () => {
+  const reply = mockReply();
+  const error = { data: { code: ":queue/dropped", "retry-after-ms": 5000 } };
+  const handled = sendQueueError(reply as unknown as import("fastify").FastifyReply, error);
+  assert.strictEqual(handled, true);
+  assert.strictEqual(reply.getStatus(), 429);
+  assert.strictEqual(reply.getHeaders()["retry-after"], "5");
+});
+
+test("sendQueueError: queue/total-timeout returns 429 with retry-after", () => {
+  const reply = mockReply();
+  const error = { data: { code: ":queue/total-timeout", attempt: 1, "retry-after-ms": 5000 } };
+  const handled = sendQueueError(reply as unknown as import("fastify").FastifyReply, error);
+  assert.strictEqual(handled, true);
+  assert.strictEqual(reply.getStatus(), 429);
+  assert.strictEqual(reply.getHeaders()["retry-after"], "5");
+});
+
+test("sendQueueError: queue/attempt-timeout returns 429 with retry-after", () => {
+  const reply = mockReply();
+  const error = { data: { code: ":queue/attempt-timeout", attempt: 0, "retry-after-ms": 5000 } };
+  const handled = sendQueueError(reply as unknown as import("fastify").FastifyReply, error);
+  assert.strictEqual(handled, true);
+  assert.strictEqual(reply.getStatus(), 429);
+  assert.strictEqual(reply.getHeaders()["retry-after"], "5");
+});
+
+test("sendQueueError: queue/exhausted returns 429 with retry-after", () => {
+  const reply = mockReply();
+  const error = { data: { code: ":queue/exhausted", "retry-after-ms": 10000 } };
+  const handled = sendQueueError(reply as unknown as import("fastify").FastifyReply, error);
+  assert.strictEqual(handled, true);
+  assert.strictEqual(reply.getStatus(), 429);
+  assert.strictEqual(reply.getHeaders()["retry-after"], "10");
+});
+
+test("sendQueueError: queue/full returns 429 with retry-after (unchanged)", () => {
+  const reply = mockReply();
+  const error = { data: { code: ":queue/full", "retry-after-ms": 3000 } };
+  const handled = sendQueueError(reply as unknown as import("fastify").FastifyReply, error);
+  assert.strictEqual(handled, true);
+  assert.strictEqual(reply.getStatus(), 429);
+  assert.strictEqual(reply.getHeaders()["retry-after"], "3");
+});
+
+test("sendQueueError: unknown error returns false", () => {
+  const reply = mockReply();
+  const handled = sendQueueError(reply as unknown as import("fastify").FastifyReply, new Error("something else"));
+  assert.strictEqual(handled, false);
+  assert.strictEqual(reply.getStatus(), 0);
+});

--- a/src/tests/queue-signal.test.ts
+++ b/src/tests/queue-signal.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { assertCljsRuntimeReady, loadCljsRuntime } from "../lib/cljs-runtime.js";
+import { loadCljsRuntime } from "../lib/cljs-runtime.js";
 
 test("runQueued attaches extendTimeout to AbortController signal", async (t) => {
   const loaded = await loadCljsRuntime({ required: false });
@@ -29,7 +29,7 @@ test("runQueued attaches extendTimeout to AbortController signal", async (t) => 
 
   assert.ok(capturedSignal, "signal should be captured");
   assert.ok(
-    typeof (capturedSignal as any).extendTimeout === "function",
+    typeof (capturedSignal as AbortSignal & { extendTimeout?: () => void }).extendTimeout === "function",
     "signal should have extendTimeout function",
   );
 });
@@ -60,6 +60,28 @@ test("runQueued signal extendTimeout is callable", async (t) => {
   assert.ok(capturedSignal);
   // Should not throw
   assert.doesNotThrow(() => {
-    (capturedSignal as any).extendTimeout();
+    (capturedSignal as AbortSignal & { extendTimeout?: () => void }).extendTimeout?.();
   });
+});
+
+test("runQueued resolves mimo provider-specific queue instance", async (t) => {
+  const loaded = await loadCljsRuntime({ required: false });
+  if (!loaded.loaded) {
+    t.skip(`CLJS runtime artifact not built: ${loaded.reason}`);
+    return;
+  }
+
+  if (!loaded.runtime.resolveQueuePolicy) {
+    t.skip("resolveQueuePolicy not exposed by CLJS runtime");
+    return;
+  }
+
+  const result = loaded.runtime.resolveQueuePolicy(
+    "resources/policies/runtime/00-manifest.edn",
+    { "provider-id": "xiaomi", "request-kind": "chat" },
+  );
+
+  assert.equal(result?.status, "ok", "should resolve queue policy");
+  const policy = result?.policy as Record<string, unknown> | undefined;
+  assert.equal(policy?.["attempt-timeout-ms"], 60000, "xiaomi provider should get 60s attempt timeout");
 });

--- a/src/tests/queue-signal.test.ts
+++ b/src/tests/queue-signal.test.ts
@@ -1,0 +1,65 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { assertCljsRuntimeReady, loadCljsRuntime } from "../lib/cljs-runtime.js";
+
+test("runQueued attaches extendTimeout to AbortController signal", async (t) => {
+  const loaded = await loadCljsRuntime({ required: false });
+  if (!loaded.loaded) {
+    t.skip(`CLJS runtime artifact not built: ${loaded.reason}`);
+    return;
+  }
+
+  if (!loaded.runtime.runQueued) {
+    t.skip("runQueued not exposed by CLJS runtime");
+    return;
+  }
+
+  let capturedSignal: AbortSignal | undefined;
+
+  await loaded.runtime.runQueued(
+    "resources/policies/runtime/00-manifest.edn",
+    { "request-kind": "chat" },
+    async (controller: AbortController) => {
+      capturedSignal = controller.signal;
+      // Immediately resolve so we don't wait
+      return "ok";
+    },
+  );
+
+  assert.ok(capturedSignal, "signal should be captured");
+  assert.ok(
+    typeof (capturedSignal as any).extendTimeout === "function",
+    "signal should have extendTimeout function",
+  );
+});
+
+test("runQueued signal extendTimeout is callable", async (t) => {
+  const loaded = await loadCljsRuntime({ required: false });
+  if (!loaded.loaded) {
+    t.skip(`CLJS runtime artifact not built: ${loaded.reason}`);
+    return;
+  }
+
+  if (!loaded.runtime.runQueued) {
+    t.skip("runQueued not exposed by CLJS runtime");
+    return;
+  }
+
+  let capturedSignal: AbortSignal | undefined;
+
+  await loaded.runtime.runQueued(
+    "resources/policies/runtime/00-manifest.edn",
+    { "request-kind": "chat" },
+    async (controller: AbortController) => {
+      capturedSignal = controller.signal;
+      return "ok";
+    },
+  );
+
+  assert.ok(capturedSignal);
+  // Should not throw
+  assert.doesNotThrow(() => {
+    (capturedSignal as any).extendTimeout();
+  });
+});

--- a/src/tests/rate-limit-classify.test.ts
+++ b/src/tests/rate-limit-classify.test.ts
@@ -94,3 +94,13 @@ test("detectOllamaLimitKind still works: weekly", () => {
 test("detectOllamaLimitKind still works: unknown", () => {
   assert.equal(detectOllamaLimitKind({ error: "Something else" }), "unknown");
 });
+
+test("classifyRateLimitKind with providerId falls back to generic heuristics when CLJS unavailable", () => {
+  const body = { error: { message: "Too many requests" } };
+  assert.equal(classifyRateLimitKind(body, 5000, 30000, "unknown-provider"), "concurrency_throttle");
+});
+
+test("classifyRateLimitKind with providerId still applies Ollama rules", () => {
+  const body = { error: "Session usage limit reached" };
+  assert.equal(classifyRateLimitKind(body, 5000, 30000, "ollama"), "quota_exhausted");
+});


### PR DESCRIPTION
Queue errors (dropped, total-timeout, attempt-timeout, exhausted) now return HTTP 429 with a Retry-After header instead of 503. This lets opencode and other HTTP clients automatically retry after the indicated backoff period.

## Changes
- CLJS runtime: add :retry-after-ms to all queue error types
- TS edge: sendQueueError returns 429 (was 503) for timeout/dropped/exhausted
- New tests: queue-error-429.test.ts (6 tests, all pass)

## Testing
- [x] queue-signal.test.ts passes (3/3)
- [x] rate-limit-classify.test.ts passes (21/21)
- [x] queue-error-429.test.ts passes (6/6)
- [x] CLJS build succeeds
- [x] TypeScript build succeeds