### PR TITLE
fix: set CI=true for web PM2 process to suppress pnpm TTY prompt

### DIFF
--- a/ecosystem.container.config.cjs
+++ b/ecosystem.container.config.cjs
@@ -24,7 +24,8 @@ module.exports = {
       args: ["exec", "vite", "preview", "--config", "web/vite.config.ts", "--host", "0.0.0.0", "--port", "5174"],
       cwd: "/app",
       env: {
-        NODE_ENV: "production"
+        NODE_ENV: "production",
+        CI: "true"
       },
       autorestart: true,
       watch: false,


### PR DESCRIPTION
## Summary
- `open-hax-openai-proxy-web` (PM2 app `:1`) was crash-looping in the container with `ERR_PNPM_ABORTED_REMOVE_MODULES_DIR_NO_TTY`
- pnpm detects a stale/mismatched modules dir on startup and tries to purge it, but aborts because there's no TTY to confirm interactively
- After 10 restarts PM2 marks the process as "errored" — the web UI goes down
- Fix: add `CI: "true"` to the web process env in `ecosystem.container.config.cjs` so pnpm proceeds non-interactively

## Test plan
- [ ] Rebuild and redeploy the container; verify `open-hax-openai-proxy-web` comes up cleanly without crash-looping

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated environment configuration for the proxy service to enable continuous integration mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->